### PR TITLE
Fix portfolio thumbnail paths

### DIFF
--- a/src/pages/portfolio/index.astro
+++ b/src/pages/portfolio/index.astro
@@ -5,13 +5,15 @@ import PortfolioNav from '../../layouts/PortfolioNav.astro';
 const items = (await getCollection('portfolio')).sort(
   (a, b) => b.data.date.getTime() - a.data.date.getTime()
 );
+
+const thumbUrl = (thumb: string) => thumb.startsWith('/') ? thumb : `/${thumb}`;
 ---
 <PortfolioNav>
   <ul class="pbox">
     {items.map((item) => (
       <li class="pitem">
         <a href={`/portfolio/${item.slug}/`} style="color: black">
-          <div style={`background-color:black; background-image: url(/${item.data.thumb}); background-size: 100%; height: 100%; background-repeat: no-repeat; background-position: center center;`}>
+          <div style={`background-color:black; background-image: url(${thumbUrl(item.data.thumb)}); background-size: 100%; height: 100%; background-repeat: no-repeat; background-position: center center;`}>
             <div class="poverlay">
               <h2 class="pheading">{item.data.name}</h2>
               {item.data.startdate && (


### PR DESCRIPTION
Thumb paths with leading slashes were getting double-slashed (e.g. `//images/...`) which resolved as protocol-relative URLs and failed to load.