### PR TITLE
Add Exclosure and OrbitalCommons to homepage

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -23,6 +23,16 @@ import Default from '../layouts/Default.astro';
               We do events at museums, Burning Man, and other venues.
           </li>
           <li>
+            <em><a href="http://www.exclosure.io">Exclosure</a></em> is a company I founded
+              to build a worldwide space monitoring network. We designed and manufactured
+              ~30 custom optical telescopes operating around the clock globally.
+          </li>
+          <li>
+            <em><a href="https://github.com/OrbitalCommons">OrbitalCommons</a></em> is a
+              collection of open-source astrometry tools I maintain, including a blind
+              plate solver, a star field library, and FITS file utilities.
+          </li>
+          <li>
             <em><a href="https://github.com/meawoppl">Github</a></em>
               is the place that keep the software I develop.
           </li>


### PR DESCRIPTION
Adds entries for Exclosure (space monitoring network) and OrbitalCommons (open-source astrometry tools) to the 'things I have done' section.