### PR TITLE
Portfolio grid 4 columns

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -155,7 +155,7 @@ img.rounded_full_nointerp {
 ul.pbox {
   display: grid;
   grid-gap: 10px;
-  grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
   list-style-type: none;
   font-family: "Times New Roman", Times, serif;
 }


### PR DESCRIPTION
Changes grid minmax from 350px to 250px so 4 columns fit on desktop. Still collapses responsively on smaller screens.