### PR TITLE
Fix portfolio heading word break

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -181,6 +181,7 @@ div.poverlay {
 
 h2.pheading {
   margin-bottom: 0px;
+  white-space: nowrap;
 }
 
 // Blog post image styling


### PR DESCRIPTION
Adds white-space: nowrap to h2.pheading so names like InboxNegative don't split mid-word in the thumbnail overlay.