### PR TITLE
Left-align portfolio overlay box

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -173,8 +173,7 @@ div.poverlay {
   position: relative;
   display: inline-block;
   top: 5%;
-  left: 5%;
-  width: 35%;
+  left: 0;
   opacity: 0.70;
   background-color: aliceblue;
 }


### PR DESCRIPTION
## Summary
- Moved overlay box to `left: 0` (was `left: 5%`)
- Removed fixed `width: 35%` so the box auto-sizes to fit nowrap heading text