### PR TITLE
Add PasteBom portfolio entry

### DIFF
--- a/public/images/pastebom/logo.svg
+++ b/public/images/pastebom/logo.svg
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- PCB board background -->
+  <rect x="8" y="8" width="112" height="112" rx="6" fill="#1a5c2a" stroke="#0d3318" stroke-width="2"/>
+  <!-- Copper traces -->
+  <path d="M 20 30 H 50 V 60 H 80" fill="none" stroke="#c87533" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 20 70 H 40 V 100 H 70" fill="none" stroke="#c87533" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 80 30 V 50 H 108" fill="none" stroke="#c87533" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M 70 100 H 108" fill="none" stroke="#c87533" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- Pads / vias -->
+  <circle cx="20" cy="30" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="80" cy="60" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="80" cy="30" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="20" cy="70" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="70" cy="100" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="108" cy="50" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <circle cx="108" cy="100" r="5" fill="#c87533" stroke="#a05a20" stroke-width="1"/>
+  <!-- Component outlines (silkscreen) -->
+  <rect x="44" y="72" width="20" height="12" rx="1" fill="none" stroke="#e8e8c8" stroke-width="1.5"/>
+  <rect x="85" y="55" width="16" height="10" rx="1" fill="none" stroke="#e8e8c8" stroke-width="1.5"/>
+  <!-- IC package -->
+  <rect x="55" y="35" width="22" height="22" rx="2" fill="#333" stroke="#e8e8c8" stroke-width="1.5"/>
+  <circle cx="60" cy="40" r="2" fill="#e8e8c8"/>
+  <!-- Drill holes -->
+  <circle cx="16" cy="16" r="3" fill="#222"/>
+  <circle cx="112" cy="16" r="3" fill="#222"/>
+  <circle cx="16" cy="112" r="3" fill="#222"/>
+  <circle cx="112" cy="112" r="3" fill="#222"/>
+</svg>

--- a/src/content/portfolio/pastebom.md
+++ b/src/content/portfolio/pastebom.md
@@ -1,0 +1,15 @@
+---
+date: 2026-01-03
+name: PasteBom
+thumb: /images/pastebom/logo.svg
+---
+
+[PasteBom](https://pastebom.com) is a shareable interactive PCB Bill of Materials viewer. Upload a board file from KiCad, EasyEDA, Eagle, or Altium and get a link to an interactive viewer with a searchable BOM table.
+
+The viewer renders front and back board views on stacked HTML5 canvases with click-to-highlight for nets and components, layer visibility toggles, pan/zoom/rotate, and dark mode.
+
+The whole stack is Rust:
+
+* **pcb-extract** — A parser library that reads `.kicad_pcb`, EasyEDA JSON, Eagle XML, and Altium `.pcbdoc` files into a common intermediate representation.
+* **pastebom-server** — An Axum/Tokio HTTP server handling multipart uploads, S3-backed storage, and serving the viewer.
+* **pastebom-viewer** — A Yew/WASM frontend compiled with Trunk, rendering interactive board views on canvas with path caching for performance.


### PR DESCRIPTION
## Summary
- New portfolio entry for PasteBom.com — interactive PCB BOM viewer
- Added PCB-themed SVG thumbnail
- Covers multi-format parser, Axum server, and Yew/WASM viewer