### PR TITLE
Add Claude Code Portal and Embedded FPGA portfolio entries

### DIFF
--- a/public/images/cc-proxy/logo.svg
+++ b/public/images/cc-proxy/logo.svg
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- Terminal window -->
+  <rect x="8" y="16" width="112" height="96" rx="8" fill="#1e1e2e" stroke="#585b70" stroke-width="2"/>
+  <!-- Title bar -->
+  <rect x="8" y="16" width="112" height="20" rx="8" fill="#313244"/>
+  <rect x="8" y="28" width="112" height="8" fill="#313244"/>
+  <!-- Window buttons -->
+  <circle cx="22" cy="26" r="4" fill="#f38ba8"/>
+  <circle cx="34" cy="26" r="4" fill="#f9e2af"/>
+  <circle cx="46" cy="26" r="4" fill="#a6e3a1"/>
+  <!-- Terminal prompt lines -->
+  <rect x="18" y="46" width="8" height="3" rx="1" fill="#a6e3a1"/>
+  <rect x="30" y="46" width="50" height="3" rx="1" fill="#cdd6f4"/>
+  <rect x="18" y="56" width="8" height="3" rx="1" fill="#a6e3a1"/>
+  <rect x="30" y="56" width="35" height="3" rx="1" fill="#cdd6f4"/>
+  <rect x="18" y="66" width="8" height="3" rx="1" fill="#a6e3a1"/>
+  <rect x="30" y="66" width="60" height="3" rx="1" fill="#cdd6f4"/>
+  <!-- Cursor -->
+  <rect x="18" y="76" width="8" height="3" rx="1" fill="#a6e3a1"/>
+  <rect x="30" y="76" width="6" height="3" rx="1" fill="#f5c2e7">
+    <animate attributeName="opacity" values="1;0;1" dur="1s" repeatCount="indefinite"/>
+  </rect>
+  <!-- WiFi/connection icon -->
+  <path d="M 96 50 Q 104 42, 112 50" fill="none" stroke="#89b4fa" stroke-width="2" stroke-linecap="round"/>
+  <path d="M 99 54 Q 104 49, 109 54" fill="none" stroke="#89b4fa" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="104" cy="57" r="2" fill="#89b4fa"/>
+</svg>

--- a/public/images/embedded-fpga/logo.svg
+++ b/public/images/embedded-fpga/logo.svg
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="128" height="128" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+  <!-- PCB substrate -->
+  <rect x="4" y="4" width="120" height="120" rx="4" fill="#1a3a2a" stroke="#0d2318" stroke-width="1.5"/>
+  <!-- FPGA die -->
+  <rect x="36" y="36" width="56" height="56" rx="3" fill="#2a2a3a" stroke="#555" stroke-width="1.5"/>
+  <!-- Die marking -->
+  <circle cx="46" cy="46" r="3" fill="#666"/>
+  <!-- Pin grid - top -->
+  <rect x="44" y="28" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="54" y="28" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="64" y="28" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="74" y="28" width="4" height="10" rx="1" fill="#c87533"/>
+  <!-- Pin grid - bottom -->
+  <rect x="44" y="90" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="54" y="90" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="64" y="90" width="4" height="10" rx="1" fill="#c87533"/>
+  <rect x="74" y="90" width="4" height="10" rx="1" fill="#c87533"/>
+  <!-- Pin grid - left -->
+  <rect x="28" y="44" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="28" y="54" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="28" y="64" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="28" y="74" width="10" height="4" rx="1" fill="#c87533"/>
+  <!-- Pin grid - right -->
+  <rect x="90" y="44" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="90" y="54" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="90" y="64" width="10" height="4" rx="1" fill="#c87533"/>
+  <rect x="90" y="74" width="10" height="4" rx="1" fill="#c87533"/>
+  <!-- Traces from pins -->
+  <path d="M 46 28 V 18 H 20" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M 76 28 V 14 H 110" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M 46 100 V 110 H 16" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M 76 100 V 114 H 108" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M 28 46 H 16 V 20" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M 100 76 H 112 V 108" fill="none" stroke="#c87533" stroke-width="1.5" stroke-linecap="round"/>
+  <!-- Clock signal indicator -->
+  <path d="M 50 60 L 54 60 L 54 54 L 58 54 L 58 60 L 62 60 L 62 54 L 66 54 L 66 60 L 70 60 L 70 54 L 74 54 L 74 60 L 78 60" fill="none" stroke="#a6e3a1" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <!-- PPS label -->
+  <text x="64" y="78" font-family="monospace" font-size="9" fill="#89b4fa" text-anchor="middle">PPS</text>
+</svg>

--- a/src/content/portfolio/cc-proxy.md
+++ b/src/content/portfolio/cc-proxy.md
@@ -1,0 +1,18 @@
+---
+date: 2026-01-08
+name: Claude Code Portal
+thumb: /images/cc-proxy/logo.svg
+---
+
+[Claude Code Portal](https://github.com/meawoppl/cc-proxy) is a web-based proxy that extends Claude Code with remote access and session sharing. Run Claude Code on a powerful machine and access it from any browser — phone, tablet, or thin client.
+
+The system intercepts Claude's terminal I/O via a lightweight CLI wrapper (`claude-portal`), forwards everything over WebSocket to a central server, and renders it in a browser-based terminal UI. Multiple clients can view the same session in real-time.
+
+The whole stack is Rust:
+
+* **Backend** — Axum 0.7 with Diesel/PostgreSQL for session persistence, WebSocket endpoints for real-time sync, and Google OAuth for authentication.
+* **Frontend** — A Yew/WASM app with a terminal-style interface, voice input via browser speech recognition, and live cost tracking.
+* **Proxy CLI** — A native binary that wraps Claude Code, transparently capturing stdin/stdout and relaying to the backend.
+* **Shared** — A WASM-safe crate of protocol types shared between frontend and backend, eliminating serialization boilerplate.
+
+Features include configurable message retention, session sharing with role-based permissions, device-flow OAuth for CLI auth, and background cost tracking that broadcasts token usage to connected clients.

--- a/src/content/portfolio/embedded-fpga.md
+++ b/src/content/portfolio/embedded-fpga.md
@@ -1,0 +1,21 @@
+---
+date: 2025-10-04
+name: Embedded FPGA
+thumb: /images/embedded-fpga/logo.svg
+---
+
+Two projects built around the IcedEspresso board — an ESP32-S2 paired with a Lattice ICE40UP5K FPGA.
+
+## Affogato
+
+[Affogato](https://github.com/meawoppl/affogato) is a CLI tool that wraps the entire ESP32 + ICE40 development workflow into a single command. It manages a Docker container with the full FPGA toolchain (Yosys, nextpnr, icestorm) and ESP-IDF, so there's no host installation to fight with.
+
+`affogato build` synthesizes the Verilog, packs the bitstream, embeds it into the ESP32 firmware binary, and compiles everything. The FPGA bitstream gets soft-loaded over SPI at boot. It also supports watch mode with debounced rebuilds, testbench discovery and simulation via iverilog, and Verilator linting.
+
+The tool ships with a library of reusable Verilog modules — SPI slave (bulk and register modes), clock domain crossing, edge detection, and an RGB LED driver — plus an ESP-IDF component that handles FPGA loading and SPI communication.
+
+## GPS Time Calibrator
+
+[GPS Time Calibrator](https://github.com/meawoppl/gps-time-calibrator) is a precision timing system that synchronizes camera timestamps using GPS pulse-per-second signals. The FPGA measures clock cycles between PPS pulses at 48 MHz resolution, and a rolling average provides stable frequency calibration. The ESP32 parses GPS serial data, manages WiFi, and runs a Stratum 1 NTP server with sub-microsecond precision.
+
+The FPGA side is built from modular Verilog — an interval counter, health monitor (tracks consecutive good pulses before reporting lock), and frequency averager, each with independent testbenches. The ESP32 reads FPGA state over a clean SPI register interface with value latching to avoid torn reads across clock domains.


### PR DESCRIPTION
## Summary
- **Claude Code Portal** — web proxy for remote Claude Code access with session sharing, Rust full-stack (Axum/Yew/WASM)
- **Embedded FPGA** — combined entry for Affogato (ESP32+ICE40 dev CLI) and GPS Time Calibrator (precision timing with FPGA PPS measurement)
- SVG thumbnails for both entries