### PR TITLE
Add padding to portfolio overlay text

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -174,6 +174,7 @@ div.poverlay {
   display: inline-block;
   top: 5%;
   left: 0;
+  padding: 0 0.75em;
   opacity: 0.70;
   background-color: aliceblue;
 }


### PR DESCRIPTION
Adds horizontal padding (0.75em) to the overlay box so text isn't flush against the edges.