### PR TITLE
Remove top margin from portfolio heading

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -180,7 +180,8 @@ div.poverlay {
 }
 
 h2.pheading {
-  margin-bottom: 0px;
+  margin-top: 0;
+  margin-bottom: 0;
   white-space: nowrap;
 }
 


### PR DESCRIPTION
Zeros out the default h2 top margin so the title sits snug in the overlay box.