### PR TITLE
Fix mobile overflow on blog post images

### DIFF
--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -185,6 +185,11 @@ h2.pheading {
   white-space: nowrap;
 }
 
+// Prevent flex children from overflowing viewport on mobile
+main.cell {
+  min-width: 0;
+}
+
 // Blog post image styling
 .post img, .post-content img {
   max-width: 100%;


### PR DESCRIPTION
## Summary
- Add `min-width: 0` to `main.cell` flex child so images can shrink below their intrinsic size on mobile
- Fixes the software maintenance blog post (and any other post with wide images) rendering too wide on mobile

## Test plan
- [ ] View the software maintenance blog post on a mobile device or narrow viewport
- [ ] Verify images resize to fit the screen and text doesn't overflow horizontally