### PR TITLE
Add CI build check for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build with Astro
+        run: npm run build


### PR DESCRIPTION
## Summary
- Adds a CI workflow that runs `npm run build` on every PR targeting master
- Uses Node 20 with npm caching for fast runs
- Will be used as a required status check via branch protection

## Test plan
- [ ] CI runs on this PR itself