### PR TITLE
Add media list link to front page

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,6 +87,7 @@ import Default from '../layouts/Default.astro';
           <li>Cinema/TV - Ghost in the Shell, Rick and Morty, Existenz, Blade Runner</li>
           <li>Modern Scientists - Martine Rothblatt, Eric Chaisson, Ed Boyden, Karl Deisseroth, Robert Erdmann, Ed Catmull</li>
           <li>Historic Scientists - Von Nuemann, Tesla, Einstein, Marconi, Claussius</li>
+          <li><em><a href="https://meawoppl.github.io/media-list/">Full media list</a></em></li>
         </ul>
       </p>
     </section>


### PR DESCRIPTION
## Summary
- Adds a link to the media-list site in the inspirations section on the front page

## Test plan
- [ ] CI build passes
- [ ] Link renders on front page and points to https://meawoppl.github.io/media-list/