### PR TITLE
Move media list link to nav menu

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -11,6 +11,7 @@ const navItems = [
   { text: 'Blog', url: '/blog/' },
   { text: 'Resume', url: '/resume/MatthewGoodman.pdf' },
   { text: 'Press', url: '/press/' },
+  { text: 'Media List', url: 'https://meawoppl.github.io/media-list/' },
 ];
 ---
 <div class="t-hackcss-navigation">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -87,7 +87,6 @@ import Default from '../layouts/Default.astro';
           <li>Cinema/TV - Ghost in the Shell, Rick and Morty, Existenz, Blade Runner</li>
           <li>Modern Scientists - Martine Rothblatt, Eric Chaisson, Ed Boyden, Karl Deisseroth, Robert Erdmann, Ed Catmull</li>
           <li>Historic Scientists - Von Nuemann, Tesla, Einstein, Marconi, Claussius</li>
-          <li><em><a href="https://meawoppl.github.io/media-list/">Full media list</a></em></li>
         </ul>
       </p>
     </section>


### PR DESCRIPTION
## Summary
- Move media list link from the inspirations section on the front page into the site navigation menu

## Test plan
- [ ] CI build passes
- [ ] Media List appears in nav on all pages
- [ ] Link removed from front page inspirations section