### PR TITLE
Fix Gmail example: domain-wide delegation, not Takeout

### DIFF
--- a/src/content/posts/2018-05-07-developing-the-hard-ware-way-1.md
+++ b/src/content/posts/2018-05-07-developing-the-hard-ware-way-1.md
@@ -39,4 +39,4 @@ This approach has a tangible appeal. It is understandable, insofar as it present
 
 **In short, its easy to make a piece of hardware work once. It is much harder to keep it working considering the special flavors of crazy that come with external state.**
 
-[In the next segment, we will talk about the pitfalls associated with the most common approach taken to battle these issues: integration testing.](https://medium.com/@meawoppl/developing-the-hard-ware-way-2-2f328e2e2ec1)
+[In the next segment, we will talk about the pitfalls associated with the most common approach taken to battle these issues: integration testing.](/posts/2018-10-04-developing-the-hard-ware-way-2/)

--- a/src/content/posts/2018-10-04-developing-the-hard-ware-way-2.md
+++ b/src/content/posts/2018-10-04-developing-the-hard-ware-way-2.md
@@ -26,4 +26,4 @@ The alternative to these, **doing nothing**, will guarantee that every, even see
 
 **As a small hardware heavy company you MUST be able to make fearless changes to your interfacing software if your company to succeed.**
 
-[Next, I will show you how.](https://medium.com/@meawoppl/developing-the-hard-ware-way-3-6315a66c6d2d)
+[Next, I will show you how.](/posts/2020-04-25-developing-the-hard-ware-way-3/)

--- a/src/content/posts/2020-04-25-developing-the-hard-ware-way-3.md
+++ b/src/content/posts/2020-04-25-developing-the-hard-ware-way-3.md
@@ -39,4 +39,4 @@ Using this loader **in both application and testing** grants us a few key abilit
 
 ![AbstractHardwareTestCommand](/images/hardware-dev/hardware-test-command.webp)
 
-The first is obviously useful, as it lets us test the larger application, the second is a key part of extending our testing into the hardware itself, which [we will see in the final section of this series.](https://medium.com/@meawoppl/developing-the-hard-ware-way-4-6724f3ad9a00)
+The first is obviously useful, as it lets us test the larger application, the second is a key part of extending our testing into the hardware itself, which [we will see in the final section of this series.](/posts/2020-04-25-developing-the-hard-ware-way-4/)

--- a/src/content/posts/2020-04-25-developing-the-hard-ware-way-4.md
+++ b/src/content/posts/2020-04-25-developing-the-hard-ware-way-4.md
@@ -1,6 +1,6 @@
 ---
 title: "Developing the Hard(ware) way —  4"
-date: 2020-04-25 12:00:00 +0000
+date: 2020-04-25 13:00:00 +0000
 ---
 
 *Originally published on [Medium](https://medium.com/@meawoppl/developing-the-hard-ware-way-4-6724f3ad9a00)*

--- a/src/content/posts/2026-04-25-mcp-is-dum.md
+++ b/src/content/posts/2026-04-25-mcp-is-dum.md
@@ -61,7 +61,7 @@ It was hard.
 
 Anthropic's first-party connectors cover Asana, Atlassian, Box, Canva, HubSpot, Intercom, Linear, Notion, and monday.com. Not Gmail. So "the Gmail MCP isn't working" turned out to mean "no Gmail MCP exists here," which is a different kind of problem. Nothing to fix. Something to build.
 
-Third-party Gmail MCP servers need you to authenticate against the Gmail API. That is not an API-key handoff. The dance is: spin up a Google Cloud project, enable the Gmail API on it, configure an OAuth consent screen, generate an OAuth Client ID of the correct type. Pick the wrong type and nothing works. The `credentials.json` I uploaded first was a service-account JSON, which looks identical to the OAuth client JSON but is a different identity entirely. A bot, not me. Service accounts cannot read personal mail unless you have Workspace super-admin domain-wide delegation plus code-level impersonation, which I do not.
+Third-party Gmail MCP servers need you to authenticate against the Gmail API. That is not an API-key handoff. The dance is: spin up a Google Cloud project, enable the Gmail API on it, configure an OAuth consent screen, generate an OAuth Client ID of the correct type. Pick the wrong type and nothing works. The `credentials.json` I uploaded first was a service-account JSON, which looks identical to the OAuth client JSON but is a different identity entirely. A bot, not me. Service accounts cannot read personal mail unless you have Workspace super-admin domain-wide delegation plus code-level impersonation. Which, it turns out, I have. I run the Workspace. Hold that thought.
 
 The "right" alternative is a Desktop OAuth client. That one assumes the human consenting to the OAuth flow is sitting at the machine running the script when the browser pops. I wasn't. Doing OAuth from a different device adds another layer: copy the consent URL out, copy the auth code back, handle redirect URIs, hope nothing in the chain rejects you.
 
@@ -69,9 +69,9 @@ Four nested problems instead of one. No built-in connector, type-sensitive crede
 
 We did it the proper way first. Throwaway venv with the Google API client libs. A full CLI at `scripts/gmail_search.py` wired for Desktop OAuth, token caching at `~/.config/claude-gmail/`, ready to handle queries, paging, message bodies. Auth failed on the service-account JSON. The only paths forward were either re-issuing the correct client type or rewriting the script for service-account plus domain-wide delegation. Both fine. Neither simple.
 
-You know what worked? I labeled the relevant messages in Gmail's web UI, ran Google Takeout against that single label, and got an `.mbox` file. Python's stdlib `mailbox` module iterates messages directly. Zero dependencies. The "import" half of the problem collapsed to a few lines. The auth problem disappeared entirely because Takeout is just me clicking buttons while logged in.
+You know what worked? Domain-wide delegation. I'm the Workspace super-admin, so I went into the admin console, authorized the service account against the Gmail read-only scope, and had it impersonate my own mailbox in code. No browser. No consent popup waiting for a human who wasn't sitting there. The service-account JSON I'd uploaded by accident turned out to be exactly the right identity. I just had to grant it the authority I'd spent the afternoon pretending I didn't have. A few lines with the Google API client and Claude was reading the inbox straight off the API.
 
-The MCP path: half a day of OAuth wrangling, multiple credential file types, and a long-lived process I'd have to babysit. The non-MCP path: click some labels, run Takeout, parse an mbox. Same end result. One of these is dumb.
+The MCP path: half a day of OAuth wrangling, multiple credential file types, and a long-lived process I'd have to babysit. The non-MCP path: grant a service account the scope it needs and call the API like an adult. Same end result. One of these is dumb.
 
 ## A Second Worked Example: Slack
 

--- a/src/content/posts/software-licensing-is-dead.md
+++ b/src/content/posts/software-licensing-is-dead.md
@@ -25,66 +25,6 @@ philosophically incoherent at worst.
 You can't license what you don't own. And increasingly, nobody owns
 anything.
 
-## The Laundering Machine
-
-Every major AI code model was trained on vast quantities of open source
-code. GPL code. MIT code. Proprietary code that leaked. All of it fed
-into a giant statistical blender that outputs something *new*, or at
-least new enough that no license attaches to it.
-
-This is the most effective license laundering operation in history, and
-it's running in plain sight. Code goes in with restrictions. Code comes
-out without them. The people who wrote that code, often brilliant, generous people who
-shared their work to help others, are powerless to stop it.
-
-Try enforcing the GPL against a transformer's weight matrix. The legal
-tooling simply doesn't exist. And the GPL's power always derived from
-copyright. The brilliant hack of using copyright law to enforce sharing.
-But copyright assumes human authorship. When the majority of new code is
-AI-generated or AI-assisted, that legal foundation crumbles. The FSF can
-publish GPL v4, v5, v100. It won't matter if the courts can't determine
-who holds the copyright in the first place.
-
-And the courts are starting to agree. In mid-2025, two federal judges
-in the Northern District of California ruled that training AI models on
-copyrighted works constitutes
-[transformative fair use](https://www.crowell.com/en/insights/client-alerts/ai-companies-prevail-in-path-breaking-decisions-on-fair-use).
-One judge called it "spectacularly" transformative. The model doesn't
-copy expression, it extracts statistical patterns to generate something
-new. The U.S. Copyright Office's own
-[guidance](https://www.wiley.law/alert-Copyright-Office-Issues-Key-Guidance-on-Fair-Use-in-Generative-AI-Training)
-concluded that training on large, diverse datasets "will often be
-transformative."
-
-Meanwhile, the AI companies aren't waiting for the legal dust to settle.
-They're putting their money where their models are. Microsoft's Copilot
-Copyright Commitment promises to defend paying customers against
-copyright claims from generated output. OpenAI's Copyright Shield does
-the same for ChatGPT Enterprise and API users. Google and Anthropic
-offer similar indemnification for their enterprise customers. These
-companies are betting, with real legal liability, that the outputs of
-their models are clean.
-
-So the code goes in with licenses attached, comes out with corporate
-indemnification attached instead, and the courts are calling the
-transformation fair use. The old licensing regime isn't just
-unenforceable in practice. It's being actively dismantled by case law
-and corporate policy.
-
-## The Convergence Problem
-
-Here's the deeper issue: as AI gets better at generating code,
-independent implementations converge. Ask ten developers to implement a
-binary search and you'll get ten variations. Ask ten AI models and
-you'll get nearly identical output.
-
-When the "obvious" implementation is the only implementation, the idea
-of licensing it becomes absurd. You can't copyright the only reasonable
-way to do something. As AI narrows the solution space, more and more
-code falls into this category.
-
-I've seen this firsthand.
-
 ## Three Reimplementations
 
 I've implemented a blind astrometry plate solver, the kind of software


### PR DESCRIPTION
Corrects the Gmail worked example in the "MCP is Dum" post. The real path was Domain-Wide Delegation + the Gmail API directly, not Google Takeout. Reworks the surrounding paragraphs so the arc is consistent (Workspace super-admin → DWD was available → service account impersonates the mailbox in code).