### PR TITLE
Fold media-list subsite into main site; post cleanup

### DIFF
--- a/.github/workflows/validate-media-list.yml
+++ b/.github/workflows/validate-media-list.yml
@@ -1,0 +1,31 @@
+name: Validate Media List
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - "public/media-list/data/**"
+      - "scripts/media-list/**"
+      - ".github/workflows/validate-media-list.yml"
+  pull_request:
+    branches: [master]
+    paths:
+      - "public/media-list/data/**"
+      - "scripts/media-list/**"
+      - ".github/workflows/validate-media-list.yml"
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install jsonschema
+
+      - name: Validate media-list data
+        run: python scripts/media-list/validate.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,10 @@ Astro-based personal website with hack.css theme, hosted on GitHub Pages.
 - Images go in `public/images/` subdirectories
 - Portfolio thumbnails reference images via `thumb` path (leading `/` is handled by `thumbUrl()` helper)
 
+## Writing Style
+
+See [docs/writing-style.md](docs/writing-style.md) for a detailed analysis of the blog's voice and tone. Key traits: conversational and direct, dry humor, concrete numbers over vague claims, em dashes for asides, short declarative punchlines after longer explanations, profanity used deliberately for emphasis, generous with credit, opinionated without hedging. When drafting or editing blog posts, match this voice.
+
 ## Deployment
 
 - GitHub Actions deploys on push to master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,8 @@ Astro-based personal website with hack.css theme, hosted on GitHub Pages.
 - `src/content/config.ts` - Content collection schemas (Zod)
 - `src/styles/main.scss` - Consolidated stylesheet
 - `public/` - Static assets (images, resume, favicon)
+- `public/media-list/` - Standalone static media-tracking subsite served at `/media-list/` (plain HTML/CSS/JS, no Astro build)
+- `scripts/media-list/` - `validate.py` + JSON schemas for the media-list data
 
 ## Development Commands
 
@@ -29,6 +31,14 @@ Astro-based personal website with hack.css theme, hosted on GitHub Pages.
 - Press mentions go in `src/content/press/` with frontmatter: `text`, `date`, `sitetitle`, `siteurl`
 - Images go in `public/images/` subdirectories
 - Portfolio thumbnails reference images via `thumb` path (leading `/` is handled by `thumbUrl()` helper)
+
+## Media List Subsite
+
+- Static site under `public/media-list/`; served verbatim by Astro at `/media-list/` (linked from the top nav)
+- Hand-edited data lives in `public/media-list/data/` (`media.json`, `recommenders.json`); the JS fetches it at runtime
+- Categories: book, movie, tv, series, game, topic, music, podcast, article, other. Status: done, in-progress, queued
+- `recommended_by` entries must match a `recommenders.json` initial (or use the `Rando(name)` escape hatch)
+- Validate with `python scripts/media-list/validate.py` (schema check + recommender cross-refs + duplicate-title check); CI runs it via `.github/workflows/validate-media-list.yml`
 
 ## Writing Style
 

--- a/docs/writing-style.md
+++ b/docs/writing-style.md
@@ -1,0 +1,57 @@
+# Writing Style Guide
+
+Detailed analysis of the blog's writing voice, tone, structure, and patterns — derived from all 27 posts spanning 2009-2026.
+
+## Voice & Tone
+
+- **Conversational and direct** — writes like talking to a smart friend. First person throughout. Uses "you" to pull the reader in.
+- **Dry humor and sarcasm** — woven in naturally, never forced. Examples: "like some kind of animal", "set your desk on fire", "Your poor choices will become clear to you before too long", "don't hold your breath".
+- **Profanity used deliberately** — not gratuitously, but for emphasis and authenticity. "What. The. Fuck.", "fucking pain in the ass", "Fuck those people." Part of the voice, not a tic.
+- **Self-deprecating** — "I was drunk on a boat in the British Virgin Islands", freely admits mistakes and things he'd do differently.
+- **Opinionated without hedging** — takes strong positions and states them plainly. "None of it matters anymore." "Software licensing is dead." Doesn't soften with qualifiers.
+- **Generous with credit** — consistently cites inspirations, collaborators, and prior art. Credits people by name. But draws a clear line between credit and legal obligation.
+- **Authentic frustration** — when something is broken or stupid, says so directly. MIPI closed specs, Leap Motion ignoring Linux, VCs not understanding hardware.
+
+## Structure
+
+- **Leads with the problem or hook** — no throat-clearing. Opens with the tension, not the background. "Sometimes you need a device that..." "Every major LLM lab could cryptographically sign their model outputs today."
+- **Short paragraphs** — frequently single-sentence paragraphs for emphasis. "None of it matters anymore." "Literal. Uncontrolled. Flames."
+- **Bold for emphasis** — key phrases bolded inline, not just headers. Used to punch important concepts.
+- **Em dashes everywhere** — primary tool for asides, clarification, and rhythm. Strongly prefers em dashes over parentheses or commas for interjections.
+- **Headers are informal and descriptive** — "The Boot Dance", "Two Worlds, One Device", "It Gets Worse". Not academic section numbering.
+- **Numbered lists for sequences** — technical procedures get numbered steps. Conceptual points get bullets.
+- **Fragments used intentionally** — for rhythm and emphasis. "No external flash programmer." "Same split." "That felt good."
+
+## Technical Writing
+
+- **Deep detail without dumbing down** — assumes reader intelligence. Explains jargon inline when needed but doesn't over-explain.
+- **Concrete numbers over vague claims** — "104KB bitstream transfer at 20 MHz", "2.5 deaths per vendor per year", "$100,000 on six parts", "98.5% of test fields in about a second". Always specifics.
+- **Personal experience anchors everything** — every post ties back to "I built this" or "I saw this". Never purely theoretical.
+- **Code and technical artifacts included naturally** — inline code, config snippets, timing sequences. Not set apart as appendices.
+- **Analogies from physical world** — ecology for software maintenance, golf robots for hardware precision, toilet plungers for sample containers.
+
+## Sentence-Level Patterns
+
+- **Short declarative sentences after longer explanations** — builds context then delivers the punchline in 5 words. "They work." "The architecture held." "That felt good."
+- **"Turns out" as a transition** — appears multiple times across posts for revealing something surprising.
+- **"Here's the fun part" / "Here's where it gets awkward"** — flags interesting twists for the reader.
+- **Rhetorical questions** — used to set up the next section. "So what license governs zodiacal?" "Who authored that?"
+- **Repetition for rhythm** — "No jitter from software interrupts. No missed deadlines because someone's WiFi callback decided to run."
+
+## Content Patterns
+
+- **Retrospectives and "what I'd do differently"** — honest about past mistakes. Lists specific improvements, not vague regrets.
+- **Redacted sections for NDA'd work** — uses Unicode block characters creatively. Acknowledges the work exists without violating agreements.
+- **Forward-looking endings** — most posts close with what's next, what could be built, or a call to action. Not summaries.
+- **Range of length** — from 3-sentence micro-posts (CUDA textbook) to 5000-word deep dives (software licensing). Length matches the idea, never padded.
+- **Cross-references between posts** — the "Developing the Hard(ware) Way" series links between parts. Projects reference each other.
+
+## What the Writing is NOT
+
+- Not corporate or sanitized
+- Not academic despite deep technical content
+- Not clickbaity despite strong hooks
+- Not preachy — states opinions directly without moralizing
+- Never uses filler — every sentence carries weight
+- No marketing-speak, no buzzwords, no "leveraging synergies"
+- Does not explain things the reader can figure out from context

--- a/public/media-list/app.js
+++ b/public/media-list/app.js
@@ -1,0 +1,175 @@
+const DATA_BASE = "data/";
+
+let allItems = [];
+let recommenders = {};
+let recColors = {};
+let currentFilter = "unconsumed";
+let sortCol = "title";
+let sortAsc = true;
+
+const ARTICLES = ["the", "a", "an"];
+
+function libraryTitle(title) {
+  const words = title.split(" ");
+  if (words.length > 1 && ARTICLES.includes(words[0].toLowerCase())) {
+    return words.slice(1).join(" ") + ", " + words[0];
+  }
+  return title;
+}
+
+function hashStr(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function autoColor(name) {
+  const h = hashStr(name) % 360;
+  return `hsl(${h}, 55%, 45%)`;
+}
+
+function recColor(initial) {
+  if (recColors[initial]) return recColors[initial];
+  return autoColor(initial);
+}
+
+function textColor(bgColor) {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "#222" : "#fff";
+}
+
+async function loadData() {
+  try {
+    const [mediaResp, recResp] = await Promise.all([
+      fetch(DATA_BASE + "media.json"),
+      fetch(DATA_BASE + "recommenders.json"),
+    ]);
+    allItems = mediaResp.ok ? await mediaResp.json() : [];
+    const recList = recResp.ok ? await recResp.json() : [];
+    for (const r of recList) {
+      recommenders[r.initial] = r.full_name;
+      if (r.color) recColors[r.initial] = r.color;
+    }
+  } catch {
+    allItems = [];
+  }
+  render();
+}
+
+function recCount(item) {
+  return item.recommended_by ? item.recommended_by.length : 0;
+}
+
+function sortItems(items) {
+  const dir = sortAsc ? 1 : -1;
+  return items.slice().sort((a, b) => {
+    if (sortCol === "title") {
+      return dir * libraryTitle(a.title).localeCompare(libraryTitle(b.title), undefined, { sensitivity: "base" });
+    }
+    if (sortCol === "recs") {
+      return dir * (recCount(a) - recCount(b));
+    }
+    return 0;
+  });
+}
+
+function setSort(col) {
+  if (sortCol === col) {
+    sortAsc = !sortAsc;
+  } else {
+    sortCol = col;
+    sortAsc = col === "title";
+  }
+  render();
+}
+
+function sortIndicator(col) {
+  if (sortCol !== col) return "";
+  return sortAsc ? " \u25B2" : " \u25BC";
+}
+
+function render() {
+  const content = document.getElementById("content");
+  const filtered =
+    currentFilter === "all"
+      ? allItems
+      : currentFilter === "consumed"
+      ? allItems.filter((item) => item.status === "done")
+      : allItems.filter((item) => item.status !== "done");
+
+  const sorted = sortItems(filtered);
+
+  if (sorted.length === 0) {
+    content.innerHTML = "<p>No items found.</p>";
+    return;
+  }
+
+  let html = `<table>
+    <thead><tr>
+      <th class="sortable" data-col="title">Title${sortIndicator("title")}</th>
+      <th>Category</th>
+      <th>Author / Director</th>
+      <th>Year</th>
+      <th class="sortable" data-col="recs">Recommended By${sortIndicator("recs")}</th>
+      <th>Status</th>
+      <th>Rating</th>
+    </tr></thead><tbody>`;
+
+  for (const item of sorted) {
+    const creator = item.author || item.director || "";
+    const cat = item.category || "";
+    const rating = item.rating ? "\u2605".repeat(item.rating) : "";
+    const recs = (item.recommended_by || []).map((r) => {
+      const bg = recColor(r);
+      const fg = textColor(bg);
+      const fullName = esc(recommenders[r] || r);
+      return `<span class="rec-bubble" style="background:${bg};color:${fg}" title="${fullName}">${esc(r)}</span>`;
+    }).join(" ");
+    const displayTitle = libraryTitle(item.title);
+    const titleCell = item.url
+      ? `<a href="${esc(item.url)}" target="_blank">${esc(displayTitle)}</a>`
+      : esc(displayTitle);
+
+    html += `<tr>
+      <td class="col-title">${titleCell}</td>
+      <td class="col-cat">${esc(cat)}</td>
+      <td class="col-creator">${esc(creator)}</td>
+      <td class="col-year">${item.year || ""}</td>
+      <td class="col-recs">${recs}</td>
+      <td><span class="status-badge ${item.status}">${esc(item.status)}</span></td>
+      <td class="col-rating">${rating}</td>
+    </tr>`;
+  }
+
+  html += "</tbody></table>";
+  content.innerHTML = html;
+
+  content.querySelectorAll(".sortable").forEach((th) => {
+    th.addEventListener("click", () => setSort(th.dataset.col));
+  });
+}
+
+function esc(str) {
+  const d = document.createElement("div");
+  d.textContent = String(str);
+  return d.innerHTML;
+}
+
+document.querySelectorAll(".filter[data-filter]").forEach((btn) => {
+  btn.addEventListener("click", () => {
+    document.querySelectorAll(".filter[data-filter]").forEach((b) => b.classList.remove("active"));
+    btn.classList.add("active");
+    currentFilter = btn.dataset.filter;
+    render();
+  });
+});
+
+loadData();

--- a/public/media-list/data/media.json
+++ b/public/media-list/data/media.json
@@ -1,0 +1,11772 @@
+[
+  {
+    "author": "Brianna Wiest",
+    "category": "book",
+    "date_added": "2026-04-15",
+    "recommended_by": [
+      "BP"
+    ],
+    "status": "queued",
+    "title": "100 Essays That Will Change The Way You Think"
+  },
+  {
+    "title": "Far from the tree",
+    "category": "book",
+    "status": "queued",
+    "author": "Andrew Solomon",
+    "checked": true,
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Far_from_the_Tree",
+    "recommended_by": []
+  },
+  {
+    "title": "Spirit that catches you, The",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "HR"
+    ],
+    "tags": [
+      "Health",
+      "drugs"
+    ],
+    "checked": true,
+    "author": "Anne Fadiman",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/The_Spirit_Catches_You_and_You_Fall_Down"
+  },
+  {
+    "title": "Daemon",
+    "category": "book",
+    "status": "queued",
+    "author": "Daniel Suarez",
+    "checked": true,
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Daemon_(novel_series)",
+    "recommended_by": []
+  },
+  {
+    "title": "Jonathan's space report",
+    "category": "topic",
+    "status": "done",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Jonathan%27s_Space_Report",
+    "recommended_by": [
+      "SGA"
+    ],
+    "rating": 5
+  },
+  {
+    "title": "Brad nealy professor brothers",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Brad Neely",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Professor_Brothers",
+    "recommended_by": []
+  },
+  {
+    "title": "A History of Western Philosophy",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "date_added": "2026-04-01",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "author": "Bertrand Russell",
+    "year": 1945,
+    "url": "https://en.wikipedia.org/wiki/A_History_of_Western_Philosophy"
+  },
+  {
+    "title": "Mr. Robot",
+    "category": "tv",
+    "status": "done",
+    "rating": 2,
+    "checked": true,
+    "director": "Sam Esmail",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Mr._Robot",
+    "recommended_by": []
+  },
+  {
+    "title": "Baba Is You",
+    "category": "game",
+    "status": "done",
+    "rating": 5,
+    "checked": true,
+    "author": "Arvi Teikari",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Baba_Is_You",
+    "recommended_by": [
+      "ALV"
+    ]
+  },
+  {
+    "title": "Island",
+    "category": "book",
+    "status": "queued",
+    "author": "Aldous Huxley",
+    "recommended_by": [
+      "SZ"
+    ],
+    "checked": true,
+    "year": 1962,
+    "url": "https://en.wikipedia.org/wiki/Island_(Huxley_novel)"
+  },
+  {
+    "title": "Flowers for Algernon",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "MF",
+      "UN",
+      "NR"
+    ],
+    "checked": true,
+    "author": "Daniel Keyes",
+    "year": 1966,
+    "url": "https://en.wikipedia.org/wiki/Flowers_for_Algernon",
+    "rating": 5
+  },
+  {
+    "title": "Lock In",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "John Scalzi",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Lock_In",
+    "recommended_by": []
+  },
+  {
+    "title": "Blood Music",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ABR"
+    ],
+    "checked": true,
+    "author": "Greg Bear",
+    "year": 1985,
+    "url": "https://en.wikipedia.org/wiki/Blood_Music_(novel)"
+  },
+  {
+    "title": "Fez",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Fez_(video_game)"
+  },
+  {
+    "title": "Hyper Light Drifter",
+    "category": "game",
+    "status": "queued",
+    "checked": true,
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Hyper_Light_Drifter",
+    "recommended_by": [
+      "ALV"
+    ]
+  },
+  {
+    "title": "The Legend of Zelda: Breath of the Wild",
+    "status": "done",
+    "rating": 5,
+    "checked": true,
+    "category": "game",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/The_Legend_of_Zelda:_Breath_of_the_Wild",
+    "recommended_by": []
+  },
+  {
+    "title": "The Mastermind",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MKI",
+      "AF",
+      "JMA"
+    ],
+    "checked": true,
+    "author": "Evan Ratliff",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Evan_Ratliff"
+  },
+  {
+    "title": "The Inevitable",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Kevin Kelly",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/The_Inevitable_(book)",
+    "recommended_by": []
+  },
+  {
+    "title": "Generations",
+    "category": "book",
+    "status": "queued",
+    "author": "William Strauss and Neil Howe",
+    "checked": true,
+    "year": 1991,
+    "url": "https://en.wikipedia.org/wiki/Generations_(book)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Laundry Files",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Charles Stross",
+    "year": 2004,
+    "url": "https://en.wikipedia.org/wiki/The_Laundry_Files",
+    "recommended_by": []
+  },
+  {
+    "title": "The Time Machine (1960 and 2002)",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "George Pal / Simon Wells",
+    "year": 1960,
+    "url": "https://en.wikipedia.org/wiki/The_Time_Machine_(1960_film)",
+    "recommended_by": []
+  },
+  {
+    "title": "Feather Thief, The",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Kirk Wallace Johnson",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Kirk_Wallace_Johnson",
+    "recommended_by": [
+      "SK"
+    ]
+  },
+  {
+    "title": "Perfume: The Story of a Murderer",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Patrick Süskind",
+    "year": 1985,
+    "url": "https://en.wikipedia.org/wiki/Perfume_(novel)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Stanley parable",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ZG"
+    ],
+    "checked": true,
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/The_Stanley_Parable"
+  },
+  {
+    "title": "Outer Wilds",
+    "category": "game",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "ALV"
+    ],
+    "tags": [
+      "space"
+    ],
+    "checked": true,
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Outer_Wilds"
+  },
+  {
+    "title": "The Prestige",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "checked": true,
+    "author": "Christopher Priest",
+    "year": 1995,
+    "url": "https://en.wikipedia.org/wiki/The_Prestige_(novel)"
+  },
+  {
+    "title": "The Amazon Way",
+    "status": "done",
+    "recommended_by": [
+      "MEM"
+    ],
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "John Rossman",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Amazon_(company)",
+    "rating": 2
+  },
+  {
+    "title": "The Fifth Column",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Ernest Hemingway",
+    "year": 1938,
+    "url": "https://en.wikipedia.org/wiki/The_Fifth_Column_and_the_First_Forty-Nine_Stories",
+    "recommended_by": []
+  },
+  {
+    "title": "Amadeus",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Peter Shaffer",
+    "year": 1979,
+    "url": "https://en.wikipedia.org/wiki/Amadeus_(play)",
+    "recommended_by": []
+  },
+  {
+    "title": "Destino",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Dominique Monféry",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Destino",
+    "recommended_by": []
+  },
+  {
+    "title": "Where the Crawdads sing",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Delia Owens",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Where_the_Crawdads_Sing",
+    "recommended_by": [
+      "LBO"
+    ]
+  },
+  {
+    "title": "Sleeping Dogs Lie",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Bobcat Goldthwait",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Sleeping_Dogs_Lie_(2006_film)",
+    "recommended_by": []
+  },
+  {
+    "title": "Stalker",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "director": "Andrei Tarkovsky",
+    "year": 1979,
+    "url": "https://en.wikipedia.org/wiki/Stalker_(1979_film)"
+  },
+  {
+    "title": "Linchpin",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Seth Godin",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Seth_Godin",
+    "recommended_by": []
+  },
+  {
+    "title": "Bravest Warriors",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "director": "Pendleton Ward",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Bravest_Warriors",
+    "recommended_by": []
+  },
+  {
+    "title": "9",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Shane Acker",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/9_(2009_animated_film)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Ghost Map",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Steven Johnson",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/The_Ghost_Map",
+    "recommended_by": []
+  },
+  {
+    "title": "The Book Thief",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Markus Zusak",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/The_Book_Thief",
+    "recommended_by": [
+      "LBO"
+    ]
+  },
+  {
+    "title": "Mindless Eating",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MMA"
+    ],
+    "checked": true,
+    "author": "Brian Wansink",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Mindless_Eating"
+  },
+  {
+    "title": "Ascension",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Nicholas Binge",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Ascension_(Binge_novel)",
+    "recommended_by": []
+  },
+  {
+    "title": "Conspiracy",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Ryan Holiday",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Ryan_Holiday",
+    "recommended_by": []
+  },
+  {
+    "title": "Bee and PuppyCat",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "director": "Natasha Allegri",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Bee_and_PuppyCat",
+    "recommended_by": []
+  },
+  {
+    "title": "Sinews of Power",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "author": "Xu Yi-chong",
+    "year": 2017,
+    "url": "https://global.oup.com/academic/product/sinews-of-power-9780190279523"
+  },
+  {
+    "title": "Wonderstruck",
+    "category": "book",
+    "status": "queued",
+    "author": "Brian Selznick",
+    "checked": true,
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Wonderstruck_(novel)",
+    "recommended_by": []
+  },
+  {
+    "title": "Behave",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEM",
+      "MMC",
+      "SZ",
+      "WKZ"
+    ],
+    "checked": true,
+    "author": "Robert Sapolsky",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Behave_(book)"
+  },
+  {
+    "title": "The Open Society and Its Enemies",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Karl Popper",
+    "year": 1945,
+    "url": "https://en.wikipedia.org/wiki/The_Open_Society_and_Its_Enemies",
+    "recommended_by": [
+      "ALV"
+    ]
+  },
+  {
+    "title": "Ancillary Justice",
+    "category": "book",
+    "status": "queued",
+    "author": "Ann Leckie",
+    "recommended_by": [
+      "ALV",
+      "KE",
+      "SB",
+      "BMB",
+      "ROB"
+    ],
+    "checked": true,
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Ancillary_Justice"
+  },
+  {
+    "title": "Flow",
+    "category": "book",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "MEM"
+    ],
+    "tags": [
+      "Leadership",
+      "work"
+    ],
+    "checked": true,
+    "author": "Mihaly Csikszentmihalyi",
+    "year": 1990,
+    "url": "https://en.wikipedia.org/wiki/Mihaly_Csikszentmihalyi"
+  },
+  {
+    "title": "Little Bets",
+    "category": "book",
+    "status": "queued",
+    "author": "Peter Sims",
+    "recommended_by": [
+      "TW"
+    ],
+    "checked": true,
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Little_Bets"
+  },
+  {
+    "title": "Under the Banner of Heaven",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "HR"
+    ],
+    "checked": true,
+    "author": "Jon Krakauer",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Under_the_Banner_of_Heaven",
+    "rating": 5
+  },
+  {
+    "title": "A People's History of the United States",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC",
+      "ALV"
+    ],
+    "checked": true,
+    "author": "Howard Zinn",
+    "year": 1980,
+    "url": "https://en.wikipedia.org/wiki/A_People%27s_History_of_the_United_States"
+  },
+  {
+    "title": "Fast, Cheap & Out of Control",
+    "category": "movie",
+    "status": "done",
+    "recommended_by": [
+      "DO",
+      "DC"
+    ],
+    "checked": true,
+    "director": "Errol Morris",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/Fast,_Cheap_%26_Out_of_Control",
+    "rating": 3
+  },
+  {
+    "title": "Functional ultrasound imaging",
+    "category": "topic",
+    "status": "queued",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Functional_ultrasound_imaging",
+    "recommended_by": []
+  },
+  {
+    "title": "Atomic Habits",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "James Clear",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Atomic_Habits",
+    "recommended_by": []
+  },
+  {
+    "title": "The Elementary Particles",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SZ"
+    ],
+    "checked": true,
+    "author": "Michel Houellebecq",
+    "year": 1998,
+    "url": "https://en.wikipedia.org/wiki/Atomised"
+  },
+  {
+    "title": "Reading Rilke: Reflections on the Problems of Translation",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "William H. Gass",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/William_H._Gass",
+    "recommended_by": []
+  },
+  {
+    "title": "The Final Member",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "director": "Zach Math and Jonah Bekhor",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Icelandic_Phallological_Museum",
+    "recommended_by": []
+  },
+  {
+    "title": "Bastion",
+    "category": "game",
+    "status": "queued",
+    "checked": true,
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Bastion_(video_game)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Crow",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "James O'Barr",
+    "year": 1989,
+    "url": "https://en.wikipedia.org/wiki/The_Crow_(comics)",
+    "recommended_by": []
+  },
+  {
+    "title": "Sapiens: A Brief History of Humankind",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "AMC",
+      "NR"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Yuval Noah Harari",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Sapiens:_A_Brief_History_of_Humankind"
+  },
+  {
+    "title": "Make pritcher",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Name of the Wind",
+    "category": "book",
+    "status": "done",
+    "rating": 3,
+    "tags": [
+      "fantasy",
+      "magic"
+    ],
+    "checked": true,
+    "author": "Patrick Rothfuss",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/The_Name_of_the_Wind",
+    "recommended_by": []
+  },
+  {
+    "title": "The Dark Crystal",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "HR",
+      "SS"
+    ],
+    "checked": true,
+    "director": "Jim Henson and Frank Oz",
+    "year": 1982,
+    "url": "https://en.wikipedia.org/wiki/The_Dark_Crystal"
+  },
+  {
+    "title": "Jimmy Corrigan, the Smartest Kid on Earth",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Chris Ware",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/Jimmy_Corrigan,_the_Smartest_Kid_on_Earth",
+    "recommended_by": []
+  },
+  {
+    "title": "Reinventing the Sacred",
+    "status": "done",
+    "author": "Stuart Kauffman",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Stuart_Kauffman",
+    "recommended_by": []
+  },
+  {
+    "title": "Alif the Unseen",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "G. Willow Wilson",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Alif_the_Unseen",
+    "recommended_by": []
+  },
+  {
+    "title": "Gentleman Jack",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "author": "Angela Steidele",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Anne_Lister"
+  },
+  {
+    "title": "Gottman method",
+    "category": "topic",
+    "status": "queued",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/John_Gottman",
+    "recommended_by": []
+  },
+  {
+    "title": "The Story of Luke",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Alonso Mayo",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/The_Story_of_Luke",
+    "recommended_by": []
+  },
+  {
+    "title": "Artemis",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "author": "Andy Weir",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Artemis_(novel)"
+  },
+  {
+    "title": "Only the Strong",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Sheldon Lettich",
+    "year": 1993,
+    "url": "https://en.wikipedia.org/wiki/Only_the_Strong_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "It's Your Ship",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "MEM"
+    ],
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "author": "D. Michael Abrashoff",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/USS_Benfold",
+    "rating": 4
+  },
+  {
+    "title": "Vorkosigan Saga",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "author": "Lois McMaster Bujold",
+    "year": 1986,
+    "url": "https://en.wikipedia.org/wiki/Vorkosigan_Saga"
+  },
+  {
+    "title": "Zorba the Greek",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "checked": true,
+    "author": "Nikos Kazantzakis",
+    "year": 1946,
+    "url": "https://en.wikipedia.org/wiki/Zorba_the_Greek_(novel)"
+  },
+  {
+    "title": "Factorio",
+    "category": "game",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "GHS"
+    ],
+    "checked": true,
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Factorio"
+  },
+  {
+    "title": "Conflict Is Not Abuse",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SB"
+    ],
+    "checked": true,
+    "author": "Sarah Schulman",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Sarah_Schulman"
+  },
+  {
+    "title": "They Live",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "checked": true,
+    "director": "John Carpenter",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/They_Live"
+  },
+  {
+    "title": "Altered Carbon",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Richard K. Morgan",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/Altered_Carbon",
+    "recommended_by": []
+  },
+  {
+    "title": "Grace and Frankie",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "BJ"
+    ],
+    "checked": true,
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Grace_and_Frankie"
+  },
+  {
+    "title": "Changing Planes",
+    "category": "book",
+    "status": "done",
+    "author": "Ursula K. Le Guin",
+    "rating": 4,
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Changing_Planes"
+  },
+  {
+    "title": "Dirty Rotten Scoundrels",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Frank Oz",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/Dirty_Rotten_Scoundrels_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "Jitterbug Perfume",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Tom Robbins",
+    "year": 1984,
+    "url": "https://en.wikipedia.org/wiki/Jitterbug_Perfume",
+    "recommended_by": []
+  },
+  {
+    "title": "Crash Course World History",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Crash_Course_(YouTube)",
+    "recommended_by": []
+  },
+  {
+    "title": "Marcus Johnson",
+    "category": "music",
+    "status": "queued",
+    "notes": "https://en.wikipedia.org/wiki/Marcus_Johnson_(jazz_musician)",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Marcus_Johnson_(jazz_musician)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Vital Question",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SZ"
+    ],
+    "checked": true,
+    "author": "Nick Lane",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/The_Vital_Question"
+  },
+  {
+    "title": "Lou Harrison",
+    "category": "music",
+    "status": "queued",
+    "notes": "https://en.wikipedia.org/wiki/Lou_Harrison",
+    "checked": true,
+    "year": 1917,
+    "url": "https://en.wikipedia.org/wiki/Lou_Harrison",
+    "recommended_by": []
+  },
+  {
+    "title": "Freejack",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Geoff Murphy",
+    "year": 1992,
+    "url": "https://en.wikipedia.org/wiki/Freejack",
+    "recommended_by": []
+  },
+  {
+    "title": "A Fire Upon the Deep",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "AMC",
+      "SK"
+    ],
+    "checked": true,
+    "author": "Vernor Vinge",
+    "year": 1992,
+    "url": "https://en.wikipedia.org/wiki/A_Fire_Upon_the_Deep",
+    "rating": 5
+  },
+  {
+    "title": "Visions: How Science Will Revolutionize the 21st Century",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Michio Kaku",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/Visions:_How_Science_Will_Revolutionize_the_21st_Century",
+    "recommended_by": [
+      "FT"
+    ]
+  },
+  {
+    "title": "The Genius Plague",
+    "category": "book",
+    "status": "done",
+    "tags": [
+      "mycology"
+    ],
+    "checked": true,
+    "author": "David Walton",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/David_Walton_(science_fiction_writer)",
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "Log mountain soon",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HR"
+    ],
+    "checked": true
+  },
+  {
+    "title": "HyperNormalisation",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "ANE",
+      "AR"
+    ],
+    "checked": true,
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/HyperNormalisation",
+    "director": "Adam Curtis"
+  },
+  {
+    "title": "Otherland",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Tad Williams",
+    "year": 1996,
+    "url": "https://en.wikipedia.org/wiki/Otherland",
+    "recommended_by": []
+  },
+  {
+    "title": "Managing Generation X",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Bruce Tulgan",
+    "year": 1995,
+    "url": "https://en.wikipedia.org/wiki/Bruce_Tulgan",
+    "recommended_by": []
+  },
+  {
+    "title": "Drive: The Surprising Truth About What Motivates Us",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEM"
+    ],
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "author": "Daniel H. Pink",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Drive:_The_Surprising_Truth_About_What_Motivates_Us"
+  },
+  {
+    "title": "Micro Men",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MRM",
+      "MET"
+    ],
+    "checked": true,
+    "director": "Saul Metzstein",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Micro_Men"
+  },
+  {
+    "title": "Stories of Your Life and Others",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "AC",
+      "NR"
+    ],
+    "checked": true,
+    "author": "Ted Chiang",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/Stories_of_Your_Life_and_Others"
+  },
+  {
+    "title": "Managing the Unmanageable",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "author": "Mickey W. Mantle, Ron Lichty",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Managing_the_Unmanageable"
+  },
+  {
+    "title": "Degenerate Art: The Art and Culture of Glass Pipes",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Aaron Golbert",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Degenerate_Art:_The_Art_and_Culture_of_Glass_Pipes",
+    "recommended_by": [
+      "DF"
+    ]
+  },
+  {
+    "title": "Start with Why",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "MEM"
+    ],
+    "checked": true,
+    "author": "Simon Sinek",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Start_with_Why"
+  },
+  {
+    "title": "The Girl with the Dragon Tattoo",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "IC"
+    ],
+    "checked": true,
+    "author": "Stieg Larsson",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/Millennium_(novel_series)"
+  },
+  {
+    "title": "Swordfish",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Dominic Sena",
+    "year": 2001,
+    "url": "https://en.wikipedia.org/wiki/Swordfish_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "Quest for Fire",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Jean-Jacques Annaud",
+    "year": 1981,
+    "url": "https://en.wikipedia.org/wiki/Quest_for_Fire_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Magic Bush",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "director": "Trey Parker",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/The_Magic_Bush",
+    "recommended_by": []
+  },
+  {
+    "title": "The Favourite",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "checked": true,
+    "director": "Yorgos Lanthimos",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/The_Favourite_(2018_film)"
+  },
+  {
+    "title": "The Hard Thing About Hard Things",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Ben Horowitz",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Ben_Horowitz",
+    "recommended_by": []
+  },
+  {
+    "title": "The Florida Project",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Sean Baker",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/The_Florida_Project",
+    "recommended_by": []
+  },
+  {
+    "title": "Slick Rick",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Slick_Rick"
+  },
+  {
+    "title": "Seeing Like a State",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "MS",
+      "MKI",
+      "AF",
+      "SB",
+      "SVA"
+    ],
+    "checked": true,
+    "author": "James C. Scott",
+    "year": 1998,
+    "url": "https://en.wikipedia.org/wiki/Seeing_Like_a_State"
+  },
+  {
+    "title": "The Electric Kool-Aid Acid Test",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Tom Wolfe",
+    "year": 1968,
+    "url": "https://en.wikipedia.org/wiki/The_Electric_Kool-Aid_Acid_Test",
+    "recommended_by": []
+  },
+  {
+    "title": "Difficult Conversations",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Douglas Stone, Bruce Patton, Sheila Heen",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/Difficult_Conversations",
+    "recommended_by": []
+  },
+  {
+    "title": "Lost Connections",
+    "category": "book",
+    "status": "queued",
+    "author": "Johann Hari",
+    "recommended_by": [
+      "BMB"
+    ],
+    "checked": true,
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Johann_Hari"
+  },
+  {
+    "title": "Mary Gaitskill",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Mary_Gaitskill"
+  },
+  {
+    "title": "The Mists of Avalon",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Marion Zimmer Bradley",
+    "year": 1983,
+    "url": "https://en.wikipedia.org/wiki/The_Mists_of_Avalon",
+    "recommended_by": []
+  },
+  {
+    "title": "The Witness",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV",
+      "GTC",
+      "GH"
+    ],
+    "checked": true,
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/The_Witness_(2016_video_game)"
+  },
+  {
+    "title": "Reactor Idle",
+    "category": "game",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Space Opera",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EAI"
+    ],
+    "checked": true,
+    "author": "Catherynne M. Valente",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Space_Opera_(Valente_novel)"
+  },
+  {
+    "title": "Lab Girl",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "JW",
+      "LBO"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Hope Jahren",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Lab_Girl"
+  },
+  {
+    "title": "Ignition!",
+    "status": "done",
+    "recommended_by": [
+      "JW"
+    ],
+    "tags": [
+      "Rockets"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "John Drury Clark",
+    "year": 1972,
+    "url": "https://en.wikipedia.org/wiki/John_Drury_Clark",
+    "rating": 4
+  },
+  {
+    "title": "The Body Keeps the Score",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AC",
+      "JPO",
+      "SB"
+    ],
+    "checked": true,
+    "author": "Bessel van der Kolk",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/The_Body_Keeps_the_Score"
+  },
+  {
+    "title": "Xenogenesis",
+    "status": "done",
+    "recommended_by": [
+      "AC"
+    ],
+    "tags": [
+      "Gender/Race"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Octavia E. Butler",
+    "year": 1987,
+    "url": "https://en.wikipedia.org/wiki/Lilith%27s_Brood",
+    "rating": 5
+  },
+  {
+    "title": "How Not to Be Wrong",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "checked": true,
+    "author": "Jordan Ellenberg",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/How_Not_to_Be_Wrong"
+  },
+  {
+    "title": "Napoleon's Buttons",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "UN",
+      "MM"
+    ],
+    "checked": true,
+    "author": "Penny Le Couteur, Jay Burreson",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Napoleon%27s_Buttons"
+  },
+  {
+    "title": "Getting to Yes",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC"
+    ],
+    "checked": true,
+    "author": "Roger Fisher, William Ury",
+    "year": 1981,
+    "url": "https://en.wikipedia.org/wiki/Getting_to_Yes"
+  },
+  {
+    "title": "Long Now talk on point cloud extraction in astronomy: Mary Lou Jepsen",
+    "category": "topic",
+    "status": "queued",
+    "recommended_by": [
+      "NES"
+    ],
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Mary_Lou_Jepsen"
+  },
+  {
+    "title": "Parable of the Polygons",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Parable_of_the_Polygons"
+  },
+  {
+    "title": "Old Man's War",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "John Scalzi",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/Old_Man%27s_War",
+    "recommended_by": []
+  },
+  {
+    "title": "LCD Soundsystem",
+    "category": "music",
+    "status": "done",
+    "checked": true,
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/LCD_Soundsystem",
+    "recommended_by": [],
+    "rating": 4
+  },
+  {
+    "title": "The Religion of Technology",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "David F. Noble",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/David_F._Noble",
+    "recommended_by": []
+  },
+  {
+    "title": "Radioactive: Marie & Pierre Curie: A Tale of Love and Fallout",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Lauren Redniss",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Radioactive:_Marie_%26_Pierre_Curie:_A_Tale_of_Love_and_Fallout",
+    "recommended_by": [
+      "DF"
+    ]
+  },
+  {
+    "title": "Transpocalypse Now",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "In Bruges",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "checked": true,
+    "year": 2008,
+    "director": "Martin McDonagh",
+    "url": "https://en.wikipedia.org/wiki/In_Bruges"
+  },
+  {
+    "title": "The Conversation",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "year": 1974,
+    "director": "Francis Ford Coppola",
+    "url": "https://en.wikipedia.org/wiki/The_Conversation",
+    "recommended_by": []
+  },
+  {
+    "title": "Raised in Captivity",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JO"
+    ],
+    "checked": true,
+    "author": "Chuck Klosterman",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Chuck_Klosterman"
+  },
+  {
+    "title": "The Life of David Gale",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "year": 2003,
+    "director": "Alan Parker",
+    "url": "https://en.wikipedia.org/wiki/The_Life_of_David_Gale",
+    "recommended_by": []
+  },
+  {
+    "title": "Leather math",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "When Harry Met Sally...",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "year": 1989,
+    "director": "Rob Reiner",
+    "url": "https://en.wikipedia.org/wiki/When_Harry_Met_Sally...",
+    "recommended_by": []
+  },
+  {
+    "title": "Horizon Zero Dawn",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "AC",
+      "ALV",
+      "Rando(unknown)"
+    ],
+    "checked": true,
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Horizon_Zero_Dawn"
+  },
+  {
+    "title": "Ketamine: Now By Prescription",
+    "category": "article",
+    "status": "done",
+    "rating": 3,
+    "checked": true,
+    "author": "Scott Alexander",
+    "url": "https://slatestarcodex.com/2019/03/11/ketamine-now-by-prescription/",
+    "year": 2019,
+    "recommended_by": []
+  },
+  {
+    "title": "The Queen of Versailles",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "year": 2012,
+    "director": "Lauren Greenfield",
+    "url": "https://en.wikipedia.org/wiki/The_Queen_of_Versailles",
+    "recommended_by": []
+  },
+  {
+    "title": "Animal Crossing",
+    "category": "game",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "AC"
+    ],
+    "checked": true,
+    "year": 2001,
+    "url": "https://en.wikipedia.org/wiki/Animal_Crossing"
+  },
+  {
+    "title": "Transmetropolitan",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Warren Ellis",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/Transmetropolitan",
+    "recommended_by": [
+      "NR"
+    ]
+  },
+  {
+    "title": "I Contain Multitudes",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Ed Yong",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Ed_Yong",
+    "recommended_by": []
+  },
+  {
+    "title": "Annie Hall",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "year": 1977,
+    "director": "Woody Allen",
+    "url": "https://en.wikipedia.org/wiki/Annie_Hall"
+  },
+  {
+    "title": "The Psychology of Writing",
+    "category": "book",
+    "status": "queued",
+    "author": "Ronald T. Kellogg",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "year": 1994,
+    "url": "https://books.google.com/books/about/The_Psychology_of_Writing.html?id=aLIQAQAAIAAJ"
+  },
+  {
+    "title": "Transistor",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "DE"
+    ],
+    "checked": true,
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Transistor_(video_game)"
+  },
+  {
+    "title": "World of Tiers",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Philip José Farmer",
+    "year": 1965,
+    "url": "https://en.wikipedia.org/wiki/World_of_Tiers",
+    "recommended_by": []
+  },
+  {
+    "title": "The 100",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "UN",
+      "AC"
+    ],
+    "checked": true,
+    "author": "Kass Morgan",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/The_100_(novel)"
+  },
+  {
+    "title": "Sure Thing",
+    "category": "book",
+    "status": "queued",
+    "author": "David Ives",
+    "checked": true,
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/Sure_Thing_(play)",
+    "recommended_by": []
+  },
+  {
+    "title": "Waking the Tiger",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Peter A. Levine",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/Waking_the_Tiger",
+    "recommended_by": [
+      "AC"
+    ]
+  },
+  {
+    "title": "The West Wing",
+    "category": "tv",
+    "status": "queued",
+    "checked": true,
+    "director": "Aaron Sorkin",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/The_West_Wing",
+    "recommended_by": []
+  },
+  {
+    "title": "The Other Life",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Ellen Meister",
+    "year": 2011,
+    "recommended_by": [
+      "CD"
+    ]
+  },
+  {
+    "title": "The Feminine Mystique",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Betty Friedan",
+    "year": 1963,
+    "url": "https://en.wikipedia.org/wiki/The_Feminine_Mystique",
+    "recommended_by": []
+  },
+  {
+    "title": "Kitt Watkins",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The First Law",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Joe Abercrombie",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/The_First_Law",
+    "recommended_by": []
+  },
+  {
+    "title": "Golden Witchbreed",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Mary Gentle",
+    "year": 1983,
+    "url": "https://en.wikipedia.org/wiki/Golden_Witchbreed",
+    "recommended_by": []
+  },
+  {
+    "title": "The Ghost Drum: A Cat's Tale",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "PBO"
+    ],
+    "checked": true,
+    "author": "Susan Price",
+    "year": 1987,
+    "url": "https://en.wikipedia.org/wiki/The_Ghost_Drum"
+  },
+  {
+    "title": "Invisible Planets",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "author": "Ken Liu",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Invisible_Planets"
+  },
+  {
+    "title": "How the Sun Got its Spots",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GHS"
+    ],
+    "checked": true
+  },
+  {
+    "title": "It's OK to Be the Boss",
+    "category": "book",
+    "status": "queued",
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "author": "Bruce Tulgan",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/Bruce_Tulgan",
+    "recommended_by": []
+  },
+  {
+    "title": "Notational Velocity",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Notational_Velocity",
+    "recommended_by": []
+  },
+  {
+    "title": "Principles",
+    "category": "book",
+    "status": "queued",
+    "author": "Ray Dalio",
+    "recommended_by": [
+      "SK"
+    ],
+    "notes": "https://drive.google.com/drive/folders/0B9z7M9tZnFufYTdqQThvaFozOGc",
+    "checked": true,
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Principles_(book)"
+  },
+  {
+    "title": "After On",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC"
+    ],
+    "checked": true,
+    "author": "Rob Reid",
+    "year": 2017
+  },
+  {
+    "title": "Celeste",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Celeste_(video_game)"
+  },
+  {
+    "title": "Space Engineers",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Space_Engineers"
+  },
+  {
+    "title": "Parable of the Sower",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "ALV",
+      "MF"
+    ],
+    "tags": [
+      "dystopia"
+    ],
+    "checked": true,
+    "author": "Octavia E. Butler",
+    "year": 1993,
+    "url": "https://en.wikipedia.org/wiki/Parable_of_the_Sower_(novel)"
+  },
+  {
+    "title": "Now This War Has Two Sides",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Derrick Jensen",
+    "year": 2008,
+    "recommended_by": []
+  },
+  {
+    "title": "Derrick Jensen",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "url": "https://en.wikipedia.org/wiki/Derrick_Jensen_(activist)",
+    "recommended_by": []
+  },
+  {
+    "title": "Avengers: Endgame",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Anthony Russo, Joe Russo",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Avengers:_Endgame",
+    "recommended_by": []
+  },
+  {
+    "title": "The Music Man",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CDU"
+    ],
+    "checked": true,
+    "author": "Meredith Willson",
+    "year": 1957,
+    "url": "https://en.wikipedia.org/wiki/The_Music_Man"
+  },
+  {
+    "title": "The Zookeeper's Wife",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Diane Ackerman",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/The_Zookeeper%27s_Wife",
+    "recommended_by": []
+  },
+  {
+    "title": "Mortal Engines",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Christian Rivers",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Mortal_Engines_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "Galaxy Quest",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "JP"
+    ],
+    "checked": true,
+    "director": "Dean Parisot",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/Galaxy_Quest"
+  },
+  {
+    "title": "The King of Kong: A Fistful of Quarters",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Seth Gordon",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/The_King_of_Kong",
+    "recommended_by": []
+  },
+  {
+    "title": "Burn After Reading",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Joel Coen, Ethan Coen",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Burn_After_Reading",
+    "recommended_by": []
+  },
+  {
+    "title": "La La Land",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "DK"
+    ],
+    "checked": true,
+    "director": "Damien Chazelle",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/La_La_Land"
+  },
+  {
+    "title": "Dune",
+    "category": "movie",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "IC"
+    ],
+    "checked": true,
+    "director": "Denis Villeneuve",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Dune_(2021_film)"
+  },
+  {
+    "title": "Till Human Voices Wake Us",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Michael Petroni",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/Till_Human_Voices_Wake_Us_(film)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Triplets of Belleville",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "director": "Sylvain Chomet",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/The_Triplets_of_Belleville",
+    "recommended_by": []
+  },
+  {
+    "title": "Sugarfish",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "SCN"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Warped Passages",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "author": "Lisa Randall",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/Warped_Passages",
+    "recommended_by": []
+  },
+  {
+    "title": "The Overstory",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "MKI",
+      "AF"
+    ],
+    "tags": [
+      "DefiesCategoy"
+    ],
+    "checked": true,
+    "author": "Richard Powers",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/The_Overstory"
+  },
+  {
+    "title": "Wheat Belly",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "MMA"
+    ],
+    "tags": [
+      "Diet"
+    ],
+    "checked": true,
+    "author": "William Davis",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Wheat_Belly",
+    "rating": 3
+  },
+  {
+    "title": "Turing's Cathedral",
+    "status": "done",
+    "recommended_by": [
+      "CD"
+    ],
+    "tags": [
+      "software"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "George Dyson",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Turing%27s_Cathedral",
+    "rating": 5
+  },
+  {
+    "title": "Rework",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "RS"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Jason Fried, David Heinemeier Hansson",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Rework"
+  },
+  {
+    "title": "Company of One",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "UN"
+    ],
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "author": "Paul Jarvis",
+    "year": 2019,
+    "rating": 3
+  },
+  {
+    "title": "Against Method",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Paul Feyerabend",
+    "year": 1975,
+    "url": "https://en.wikipedia.org/wiki/Against_Method"
+  },
+  {
+    "title": "The High Frontier: Human Colonies in Space",
+    "status": "done",
+    "recommended_by": [
+      "MAR"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Gerard K. O'Neill",
+    "year": 1976,
+    "url": "https://en.wikipedia.org/wiki/The_High_Frontier:_Human_Colonies_in_Space",
+    "rating": 5
+  },
+  {
+    "title": "Remote: Office Not Required",
+    "status": "done",
+    "author": "Jason Fried, David Heinemeier Hansson",
+    "rating": 3,
+    "recommended_by": [
+      "RS"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2013
+  },
+  {
+    "title": "Deception",
+    "status": "done",
+    "rating": 2,
+    "recommended_by": [
+      "AJ"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Philip Roth",
+    "year": 1990,
+    "url": "https://en.wikipedia.org/wiki/Deception_(novel)"
+  },
+  {
+    "title": "Beginning Illumination: Learning the Ancient Art, Step by Step",
+    "status": "done",
+    "checked": true,
+    "category": "book",
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "Designa",
+    "status": "done",
+    "rating": 4,
+    "tags": [
+      "Art"
+    ],
+    "checked": true,
+    "category": "book",
+    "recommended_by": []
+  },
+  {
+    "title": "Fall; or, Dodge in Hell",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "ALE",
+      "NR"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Neal Stephenson",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Fall;_or,_Dodge_in_Hell"
+  },
+  {
+    "title": "Drugs 2.0",
+    "status": "done",
+    "tags": [
+      "drugs"
+    ],
+    "checked": true,
+    "category": "book",
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "PiHKAL",
+    "status": "done",
+    "rating": 4,
+    "tags": [
+      "drugs"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Alexander Shulgin, Ann Shulgin",
+    "year": 1991,
+    "url": "https://en.wikipedia.org/wiki/PiHKAL",
+    "recommended_by": []
+  },
+  {
+    "title": "TiHKAL",
+    "status": "done",
+    "recommended_by": [
+      "JW"
+    ],
+    "tags": [
+      "drugs"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Alexander Shulgin, Ann Shulgin",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/TiHKAL",
+    "rating": 4
+  },
+  {
+    "title": "Code Complete",
+    "status": "done",
+    "rating": 4,
+    "tags": [
+      "software"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Steve McConnell",
+    "year": 1993,
+    "url": "https://en.wikipedia.org/wiki/Code_Complete",
+    "recommended_by": []
+  },
+  {
+    "title": "The Purpose Driven Church",
+    "status": "done",
+    "recommended_by": [
+      "OB"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Rick Warren",
+    "year": 1995,
+    "url": "https://en.wikipedia.org/wiki/The_Purpose_Driven_Church",
+    "rating": 3
+  },
+  {
+    "title": "How to Change Your Mind",
+    "status": "done",
+    "recommended_by": [
+      "UN",
+      "NR"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Michael Pollan",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/How_to_Change_Your_Mind",
+    "rating": 3
+  },
+  {
+    "title": "Ultra-High Voltage AC/DC Grids",
+    "status": "done",
+    "tags": [
+      "e-"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Zhenya Liu",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Ultra-high-voltage_electricity_transmission",
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "The Symmetries of Things",
+    "status": "done",
+    "recommended_by": [
+      "AMC"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "John Horton Conway, Heidi Burgiel, and Chaim Goodman-Strauss",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/The_Symmetries_of_Things",
+    "rating": 5
+  },
+  {
+    "title": "Clean Code",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "TB"
+    ],
+    "tags": [
+      "software"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Robert C. Martin",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Robert_C._Martin"
+  },
+  {
+    "title": "The Clean Coder",
+    "status": "done",
+    "rating": 3,
+    "tags": [
+      "software"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Robert C. Martin",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Robert_C._Martin",
+    "recommended_by": []
+  },
+  {
+    "title": "Clean Architecture",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "TB"
+    ],
+    "tags": [
+      "software"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Robert C. Martin",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Robert_C._Martin"
+  },
+  {
+    "title": "Divine Time Management",
+    "status": "queued",
+    "tags": [
+      "work"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Elizabeth Grace Saunders",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Time_management",
+    "recommended_by": []
+  },
+  {
+    "title": "The Deep-Sky Imaging Primer",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Charles Bracken",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Astrophotography",
+    "recommended_by": []
+  },
+  {
+    "title": "Orbital Mechanics for Engineering Students",
+    "status": "done",
+    "rating": 3,
+    "checked": true,
+    "category": "book",
+    "author": "Howard D. Curtis",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Orbital_Mechanics_for_Engineering_Students",
+    "recommended_by": []
+  },
+  {
+    "title": "Quiet: The Power of Introverts in a World That Can't Stop Talking",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Susan Cain",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Quiet:_The_Power_of_Introverts_in_a_World_That_Can%27t_Stop_Talking",
+    "recommended_by": []
+  },
+  {
+    "title": "Leonardo's Lost Robots",
+    "category": "book",
+    "status": "done",
+    "rating": 3,
+    "checked": true,
+    "author": "Mark Rosheim",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Leonardo%27s_robot",
+    "recommended_by": []
+  },
+  {
+    "title": "The Toyota Way",
+    "category": "book",
+    "status": "done",
+    "checked": true,
+    "author": "Jeffrey K. Liker",
+    "year": 2004,
+    "url": "https://en.wikipedia.org/wiki/The_Toyota_Way",
+    "recommended_by": [],
+    "rating": 4
+  },
+  {
+    "title": "The First 90 Days",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "author": "Michael D. Watkins",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Michael_D._Watkins",
+    "recommended_by": []
+  },
+  {
+    "title": "Steppenwolf",
+    "status": "queued",
+    "checked": true,
+    "category": "book",
+    "author": "Hermann Hesse",
+    "year": 1927,
+    "url": "https://en.wikipedia.org/wiki/Steppenwolf_(novel)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Mathematician's Shiva",
+    "status": "queued",
+    "checked": true,
+    "category": "book",
+    "author": "Stuart Rojstaczer",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Stuart_Rojstaczer",
+    "recommended_by": []
+  },
+  {
+    "title": "A Perfect Union of Contrary Things",
+    "status": "queued",
+    "recommended_by": [
+      "RL"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Sarah Jensen",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Maynard_James_Keenan"
+  },
+  {
+    "title": "The Challenger Sale",
+    "status": "queued",
+    "checked": true,
+    "category": "book",
+    "author": "Matthew Dixon and Brent Adamson",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/The_Challenger_Sale",
+    "recommended_by": []
+  },
+  {
+    "title": "Shadows of the Mind",
+    "status": "done",
+    "author": "Roger Penrose",
+    "rating": 1,
+    "checked": true,
+    "category": "book",
+    "year": 1994,
+    "url": "https://en.wikipedia.org/wiki/Shadows_of_the_Mind",
+    "recommended_by": []
+  },
+  {
+    "title": "Rejected Princesses",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "JPO"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Jason Porath",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Rejected_Princesses"
+  },
+  {
+    "title": "On the Origin of Objects",
+    "status": "queued",
+    "recommended_by": [
+      "RL"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Brian Cantwell Smith",
+    "year": 1998,
+    "url": "https://en.wikipedia.org/wiki/Brian_Cantwell_Smith"
+  },
+  {
+    "title": "Lean In",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "author": "Sheryl Sandberg",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Lean_In",
+    "recommended_by": []
+  },
+  {
+    "title": "Let It Go",
+    "status": "done",
+    "rating": 3,
+    "checked": true,
+    "category": "book",
+    "author": "Dame Stephanie Shirley",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Stephanie_Shirley",
+    "recommended_by": []
+  },
+  {
+    "title": "The Framework of Plasma Physics",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Richard D. Hazeltine and Francois L. Waelbroeck",
+    "year": 1998,
+    "url": "https://en.wikipedia.org/wiki/Plasma_(physics)",
+    "recommended_by": []
+  },
+  {
+    "title": "Introduction to Plasma Physics and Controlled Fusion",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "author": "Francis F. Chen",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Francis_F._Chen",
+    "recommended_by": []
+  },
+  {
+    "title": "The Unincorporated Man",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "tags": [
+      "H+"
+    ],
+    "checked": true,
+    "author": "Dani Kollin and Eytan Kollin",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/The_Unincorporated_Man",
+    "recommended_by": []
+  },
+  {
+    "title": "The Three-Body Problem",
+    "status": "done",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "author": "Liu Cixin",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/The_Three-Body_Problem_(novel)",
+    "recommended_by": [
+      "NR"
+    ]
+  },
+  {
+    "title": "Ball Lightning: An Unsolved Problem in Atmospheric Physics",
+    "status": "done",
+    "author": "Mark Stenhoff",
+    "rating": 3,
+    "checked": true,
+    "category": "book",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/Ball_lightning",
+    "recommended_by": []
+  },
+  {
+    "title": "The Great Joseki Debates",
+    "status": "done",
+    "rating": 3,
+    "checked": true,
+    "category": "book",
+    "author": "Honda Kunihisa",
+    "year": 1992,
+    "url": "https://en.wikipedia.org/wiki/Joseki",
+    "recommended_by": []
+  },
+  {
+    "title": "Immortality",
+    "status": "done",
+    "author": "Stephen Cave",
+    "rating": 3,
+    "tags": [
+      "H+"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Immortality_(book)",
+    "recommended_by": []
+  },
+  {
+    "title": "The Mushroom Cultivator",
+    "status": "done",
+    "author": "Paul Stamets and J.S. Chilton",
+    "tags": [
+      "drugs"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 1983,
+    "url": "https://en.wikipedia.org/wiki/Paul_Stamets",
+    "recommended_by": [],
+    "rating": 2
+  },
+  {
+    "title": "Mycelium Running",
+    "status": "done",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "author": "Paul Stamets",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/Mycelium_Running",
+    "recommended_by": []
+  },
+  {
+    "title": "House of Leaves",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "PV"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Mark Z. Danielewski",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/House_of_Leaves"
+  },
+  {
+    "title": "Creativity, Inc.",
+    "status": "done",
+    "rating": 5,
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Ed Catmull",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Creativity,_Inc.",
+    "recommended_by": []
+  },
+  {
+    "title": "Relentless Forward Progress",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "SK"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Bryon Powell",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Bryon_Powell"
+  },
+  {
+    "title": "Cosmic Evolution",
+    "status": "done",
+    "author": "Eric Chaisson",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "year": 2001,
+    "url": "https://en.wikipedia.org/wiki/Cosmic_Evolution",
+    "recommended_by": []
+  },
+  {
+    "title": "The One Minute Manager",
+    "status": "done",
+    "rating": 2,
+    "recommended_by": [
+      "TG"
+    ],
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Ken Blanchard",
+    "year": 1982,
+    "url": "https://en.wikipedia.org/wiki/The_One_Minute_Manager"
+  },
+  {
+    "title": "The Circle",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Dave Eggers",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/The_Circle_(Eggers_novel)",
+    "recommended_by": []
+  },
+  {
+    "title": "A Game of Thrones",
+    "category": "book",
+    "status": "done",
+    "checked": true,
+    "author": "George R. R. Martin",
+    "year": 1996,
+    "url": "https://en.wikipedia.org/wiki/A_Game_of_Thrones",
+    "recommended_by": [],
+    "rating": 4
+  },
+  {
+    "title": "Matter",
+    "status": "done",
+    "author": "Iain M. Banks",
+    "checked": true,
+    "category": "book",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Matter_(novel)",
+    "recommended_by": [],
+    "rating": 5
+  },
+  {
+    "title": "Look to Windward",
+    "status": "done",
+    "author": "Iain M. Banks",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/Look_to_Windward",
+    "recommended_by": []
+  },
+  {
+    "title": "Excession",
+    "status": "done",
+    "author": "Iain M. Banks",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "year": 1996,
+    "url": "https://en.wikipedia.org/wiki/Excession",
+    "recommended_by": []
+  },
+  {
+    "title": "Crossing the Chasm",
+    "status": "done",
+    "checked": true,
+    "category": "book",
+    "author": "Geoffrey A. Moore",
+    "year": 1991,
+    "url": "https://en.wikipedia.org/wiki/Crossing_the_Chasm",
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "Anathem",
+    "status": "done",
+    "author": "Neal Stephenson",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Anathem",
+    "recommended_by": []
+  },
+  {
+    "title": "Exploding the Phone",
+    "status": "done",
+    "author": "Phil Lapsley",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Phil_Lapsley",
+    "recommended_by": []
+  },
+  {
+    "title": "Hallucinations",
+    "status": "done",
+    "author": "Oliver Sacks",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Hallucinations_(book)",
+    "recommended_by": []
+  },
+  {
+    "title": "Nexus",
+    "status": "done",
+    "author": "Ramez Naam",
+    "rating": 3,
+    "checked": true,
+    "category": "book",
+    "recommended_by": [
+      "WC"
+    ],
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Ramez_Naam"
+  },
+  {
+    "title": "Cabinet of Natural Curiosities",
+    "status": "done",
+    "rating": 5,
+    "checked": true,
+    "category": "book",
+    "author": "Albertus Seba",
+    "year": 1734,
+    "url": "https://en.wikipedia.org/wiki/Albertus_Seba",
+    "recommended_by": []
+  },
+  {
+    "title": "The Signal and the Noise",
+    "status": "done",
+    "rating": 4,
+    "checked": true,
+    "category": "book",
+    "author": "Nate Silver",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/The_Signal_and_the_Noise",
+    "recommended_by": []
+  },
+  {
+    "title": "Killing Eve",
+    "status": "queued",
+    "checked": true,
+    "category": "tv",
+    "director": "Phoebe Waller-Bridge",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Killing_Eve",
+    "recommended_by": []
+  },
+  {
+    "title": "Democracy in Chains",
+    "status": "queued",
+    "author": "Nancy MacLean",
+    "checked": true,
+    "category": "book",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Democracy_in_Chains",
+    "recommended_by": []
+  },
+  {
+    "title": "Kids These Days",
+    "status": "queued",
+    "author": "Malcolm Harris",
+    "recommended_by": [
+      "HB"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Malcolm_Harris"
+  },
+  {
+    "title": "Throwing Rocks at the Google Bus",
+    "status": "queued",
+    "checked": true,
+    "category": "book",
+    "author": "Douglas Rushkoff",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Douglas_Rushkoff",
+    "recommended_by": []
+  },
+  {
+    "title": "The Secret History of Western Esotericism Podcast",
+    "status": "queued",
+    "url": "https://shwep.net/",
+    "checked": true,
+    "category": "topic",
+    "recommended_by": []
+  },
+  {
+    "title": "The Android's Dream",
+    "status": "queued",
+    "author": "John Scalzi",
+    "recommended_by": [
+      "UN"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/The_Android%27s_Dream"
+  },
+  {
+    "title": "The Witcher",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CT"
+    ],
+    "checked": true,
+    "author": "Andrzej Sapkowski",
+    "year": 1986,
+    "url": "https://en.wikipedia.org/wiki/The_Witcher"
+  },
+  {
+    "title": "The Will to Change",
+    "status": "queued",
+    "author": "bell hooks",
+    "recommended_by": [
+      "ZA"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2004,
+    "url": "https://en.wikipedia.org/wiki/Bell_hooks"
+  },
+  {
+    "title": "Art & Fear",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "SHZ",
+      "UN"
+    ],
+    "checked": true,
+    "author": "David Bayles and Ted Orland",
+    "year": 1993,
+    "rating": 4
+  },
+  {
+    "title": "The Box",
+    "category": "book",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "AMC",
+      "IC"
+    ],
+    "checked": true,
+    "author": "Marc Levinson",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/The_Box:_How_the_Shipping_Container_Made_the_World_Smaller_and_the_World_Economy_Bigger"
+  },
+  {
+    "title": "Red Dwarf",
+    "status": "queued",
+    "checked": true,
+    "category": "tv",
+    "director": "Rob Grant and Doug Naylor",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/Red_Dwarf",
+    "recommended_by": []
+  },
+  {
+    "title": "Spider-Man: Into the Spider-Verse",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "AMC"
+    ],
+    "director": "Bob Persichetti, Peter Ramsey, Rodney Rothman",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Spider-Man:_Into_the_Spider-Verse",
+    "checked": true
+  },
+  {
+    "title": "The Art of Procrastination",
+    "category": "book",
+    "status": "queued",
+    "author": "John Perry",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/The_Art_of_Procrastination",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Cybernetics: Or Control and Communication in the Animal and the Machine",
+    "category": "book",
+    "status": "queued",
+    "author": "Norbert Wiener",
+    "recommended_by": [
+      "CD"
+    ],
+    "year": 1948,
+    "url": "https://en.wikipedia.org/wiki/Cybernetics:_Or_Control_and_Communication_in_the_Animal_and_the_Machine",
+    "checked": true
+  },
+  {
+    "title": "Communication",
+    "category": "book",
+    "status": "queued",
+    "author": "Arthur c clarke",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "No small matter",
+    "category": "book",
+    "status": "queued",
+    "author": "Karen barad",
+    "recommended_by": [
+      "MS",
+      "UN"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Drama of the Gifted Child",
+    "category": "book",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "MB"
+    ],
+    "author": "Alice Miller",
+    "year": 1979,
+    "url": "https://en.wikipedia.org/wiki/The_Drama_of_the_Gifted_Child",
+    "checked": true
+  },
+  {
+    "title": "Father Ted",
+    "category": "tv",
+    "status": "done",
+    "recommended_by": [
+      "SE"
+    ],
+    "director": "Graham Linehan, Arthur Mathews",
+    "year": 1995,
+    "url": "https://en.wikipedia.org/wiki/Father_Ted",
+    "checked": true,
+    "rating": 2
+  },
+  {
+    "title": "Foundation Trilogy",
+    "category": "book",
+    "status": "done",
+    "author": "Isaac Asimov",
+    "rating": 4,
+    "recommended_by": [
+      "NF"
+    ],
+    "year": 1951,
+    "url": "https://en.wikipedia.org/wiki/Foundation_(novel_series)",
+    "checked": true
+  },
+  {
+    "title": "Merma dog",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Wardley Maps",
+    "category": "book",
+    "status": "queued",
+    "author": "Simon Wardley",
+    "recommended_by": [
+      "AJ"
+    ],
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Wardley_map",
+    "checked": true
+  },
+  {
+    "title": "Unk",
+    "category": "book",
+    "status": "queued",
+    "author": "Fiona Raby & Tony Dunne",
+    "recommended_by": [
+      "SHZ"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Light artist",
+    "category": "topic",
+    "status": "queued",
+    "author": "Bruce Munro",
+    "url": "https://en.wikipedia.org/wiki/Bruce_Munro",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Righteous Mind",
+    "category": "book",
+    "status": "queued",
+    "author": "Jonathan Haidt",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/The_Righteous_Mind",
+    "recommended_by": [
+      "JE"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The moral roots of liberals and conservatives",
+    "category": "other",
+    "status": "queued",
+    "author": "Jonathan Haidt",
+    "year": 2008,
+    "url": "https://www.ted.com/talks/jonathan_haidt_the_moral_roots_of_liberals_and_conservatives",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "You Are Not a Gadget",
+    "category": "book",
+    "status": "queued",
+    "author": "Jaron Lanier",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Jaron_Lanier",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Abundance: The Future Is Better Than You Think",
+    "category": "book",
+    "status": "done",
+    "author": "Peter Diamandis & Steven Kotler",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Abundance:_The_Future_Is_Better_Than_You_Think",
+    "recommended_by": [
+      "LP"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "Older Than Dirt: A Wild but True History of Earth",
+    "category": "book",
+    "status": "queued",
+    "author": "Don Brown & Mike Perfit",
+    "year": 2017,
+    "recommended_by": [
+      "WKZ"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Propaganda",
+    "category": "book",
+    "status": "queued",
+    "author": "Edward Bernays",
+    "year": 1928,
+    "url": "https://en.wikipedia.org/wiki/Propaganda_(book)",
+    "recommended_by": [
+      "AJ"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Winners Take All: The Elite Charade of Changing the World",
+    "category": "book",
+    "status": "done",
+    "author": "Anand Giridharadas",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Winners_Take_All:_The_Elite_Charade_of_Changing_the_World",
+    "recommended_by": [
+      "NST",
+      "SK"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "Never Let Me Go",
+    "category": "movie",
+    "status": "queued",
+    "director": "Mark Romanek",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Never_Let_Me_Go_(2010_film)",
+    "recommended_by": [
+      "AP",
+      "FW"
+    ],
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "The Player of Games",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "LLE",
+      "NSC"
+    ],
+    "author": "Iain M. Banks",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/The_Player_of_Games",
+    "tags": [
+      "games"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Golden Age",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LLE",
+      "NSC"
+    ],
+    "author": "John C. Wright",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/The_Golden_Oecumene",
+    "checked": true
+  },
+  {
+    "title": "Steel Beach",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LLE",
+      "NSC"
+    ],
+    "author": "John Varley",
+    "year": 1992,
+    "url": "https://en.wikipedia.org/wiki/Steel_Beach",
+    "checked": true
+  },
+  {
+    "title": "Progress",
+    "category": "book",
+    "status": "queued",
+    "author": "Johan Norberg",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Johan_Norberg",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Pitchforks Are Coming… For Us Plutocrats",
+    "category": "article",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "SK"
+    ],
+    "author": "Nick Hanauer",
+    "year": 2014,
+    "url": "https://www.politico.com/magazine/story/2014/06/the-pitchforks-are-coming-for-us-plutocrats-108014",
+    "checked": true
+  },
+  {
+    "title": "The Lawfare Podcast: Andrew Bacevich on 'The Age of Illusions: How America Squandered Its Cold War Victory' - Lawfare",
+    "category": "podcast",
+    "status": "queued",
+    "year": 2020,
+    "url": "https://www.lawfaremedia.org/article/lawfare-podcast-andrew-bacevich-age-illusions-how-america-squandered-its-cold-war-victory",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ]
+  },
+  {
+    "title": "Heathers",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "UN"
+    ],
+    "director": "Michael Lehmann",
+    "year": 1989,
+    "url": "https://en.wikipedia.org/wiki/Heathers",
+    "checked": true
+  },
+  {
+    "title": "Deep Thoughts Engineering Speaker Series: John Carmack",
+    "category": "other",
+    "status": "done",
+    "rating": 4,
+    "year": 2015,
+    "url": "https://youtu.be/dSCBCk4xVa0",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "032 - High Molarity Rants · UREP",
+    "category": "podcast",
+    "status": "queued",
+    "year": 2020,
+    "url": "https://unnamedre.com/episode/32",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Six Feet Under",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "BJ"
+    ],
+    "year": 2001,
+    "url": "https://en.wikipedia.org/wiki/Six_Feet_Under_(TV_series)",
+    "checked": true
+  },
+  {
+    "title": "Reality Is Broken",
+    "status": "done",
+    "rating": 3,
+    "category": "book",
+    "author": "Jane McGonigal",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Jane_McGonigal",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "You Shall Know Our Velocity!",
+    "status": "done",
+    "author": "Dave Eggers",
+    "rating": 4,
+    "category": "book",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/You_Shall_Know_Our_Velocity",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Sex at Dawn",
+    "status": "done",
+    "rating": 3,
+    "category": "book",
+    "author": "Christopher Ryan and Cacilda Jethá",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Sex_at_Dawn",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Lovely Bones",
+    "status": "done",
+    "category": "book",
+    "author": "Alice Sebold",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/The_Lovely_Bones",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 5
+  },
+  {
+    "title": "How to Create a Mind",
+    "status": "done",
+    "rating": 3,
+    "category": "book",
+    "author": "Ray Kurzweil",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/How_to_Create_a_Mind",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "West's Respiratory Physiology",
+    "status": "done",
+    "tags": [
+      "Textbook"
+    ],
+    "category": "book",
+    "author": "John B. West",
+    "year": 1974,
+    "url": "https://en.wikipedia.org/wiki/John_B._West",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "Zero: The Biography of a Dangerous Idea",
+    "status": "done",
+    "tags": [
+      "math"
+    ],
+    "category": "book",
+    "author": "Charles Seife",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/Zero:_The_Biography_of_a_Dangerous_Idea",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "Ender's Game",
+    "status": "done",
+    "rating": 5,
+    "category": "book",
+    "author": "Orson Scott Card",
+    "year": 1985,
+    "url": "https://en.wikipedia.org/wiki/Ender%27s_Game",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Speaker for the Dead",
+    "status": "done",
+    "author": "Orson Scott Card",
+    "rating": 4,
+    "category": "book",
+    "year": 1986,
+    "url": "https://en.wikipedia.org/wiki/Speaker_for_the_Dead",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Growing Gourmet and Medicinal Mushrooms",
+    "status": "done",
+    "category": "book",
+    "author": "Paul Stamets",
+    "year": 1993,
+    "checked": true,
+    "recommended_by": [],
+    "rating": 2
+  },
+  {
+    "author": "Thomas H. Davenport, John C. Beck",
+    "category": "book",
+    "checked": true,
+    "rating": 3,
+    "status": "done",
+    "title": "The Attention Economy",
+    "year": 2001,
+    "recommended_by": []
+  },
+  {
+    "author": "Mary Doria Russell",
+    "category": "book",
+    "checked": true,
+    "rating": 5,
+    "recommended_by": [
+      "IC"
+    ],
+    "tags": [
+      "Mormans",
+      "Rockets"
+    ],
+    "title": "The Sparrow",
+    "status": "done",
+    "url": "https://en.wikipedia.org/wiki/The_Sparrow_(novel)",
+    "year": 1996
+  },
+  {
+    "author": "Samuel Arbesman",
+    "category": "book",
+    "checked": true,
+    "rating": 3,
+    "status": "done",
+    "title": "Overcomplicated",
+    "year": 2016,
+    "recommended_by": []
+  },
+  {
+    "author": "Orson Scott Card",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "tags": [
+      "Materials"
+    ],
+    "title": "Treason",
+    "url": "https://en.wikipedia.org/wiki/A_Planet_Called_Treason",
+    "year": 1988,
+    "recommended_by": [],
+    "rating": 5
+  },
+  {
+    "author": "James L. Heskett",
+    "category": "book",
+    "checked": true,
+    "rating": 3,
+    "status": "done",
+    "title": "The Culture Cycle",
+    "year": 2011,
+    "recommended_by": []
+  },
+  {
+    "author": "Randall Munroe",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "title": "What If?",
+    "url": "https://en.wikipedia.org/wiki/What_If%3F_(book)",
+    "year": 2014,
+    "recommended_by": [],
+    "rating": 4
+  },
+  {
+    "author": "Henry S. Warren Jr.",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "title": "Hacker's Delight",
+    "url": "https://en.wikipedia.org/wiki/Hacker%27s_Delight",
+    "year": 2002,
+    "recommended_by": [],
+    "rating": 4
+  },
+  {
+    "author": "Orson Scott Card",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "title": "Xenocide",
+    "url": "https://en.wikipedia.org/wiki/Xenocide",
+    "year": 1991,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "author": "Frank B. Gilbreth Jr., Ernestine Gilbreth Carey",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "title": "Cheaper by the Dozen",
+    "url": "https://en.wikipedia.org/wiki/Cheaper_by_the_Dozen",
+    "year": 1948,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "author": "Mike Rother",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "tags": [
+      "Leadership"
+    ],
+    "title": "Toyota Kata",
+    "url": "https://en.wikipedia.org/wiki/Toyota_Kata",
+    "year": 2009,
+    "recommended_by": [],
+    "rating": 5
+  },
+  {
+    "title": "Leadership Is an Art",
+    "status": "done",
+    "author": "Max De Pree",
+    "category": "book",
+    "year": 1987,
+    "url": "https://en.wikipedia.org/wiki/Max_De_Pree",
+    "rating": 4,
+    "tags": [
+      "Leadership"
+    ],
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Alchemist",
+    "status": "done",
+    "author": "Paulo Coelho",
+    "category": "book",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/The_Alchemist_(novel)",
+    "recommended_by": [
+      "JPI"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "The Field Guide to Human-Centered Design",
+    "status": "done",
+    "author": "IDEO.org",
+    "category": "book",
+    "year": 2015,
+    "rating": 3,
+    "recommended_by": [
+      "SK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Bicycling Science",
+    "status": "done",
+    "author": "Frank Rowland Whitt and David Gordon Wilson",
+    "category": "book",
+    "year": 1974,
+    "rating": 5,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Have Fun Inventing",
+    "status": "done",
+    "author": "Steven M. Johnson",
+    "category": "book",
+    "year": 2012,
+    "rating": 5,
+    "tags": [
+      "Art"
+    ],
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "How to Solve It",
+    "status": "done",
+    "author": "George Pólya",
+    "category": "book",
+    "year": 1945,
+    "url": "https://en.wikipedia.org/wiki/How_to_Solve_It",
+    "rating": 5,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Critical Path",
+    "status": "done",
+    "author": "R. Buckminster Fuller",
+    "category": "book",
+    "year": 1981,
+    "url": "https://en.wikipedia.org/wiki/Critical_Path_(book)",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "The Computer and the Brain",
+    "status": "done",
+    "author": "John von Neumann",
+    "category": "book",
+    "year": 1958,
+    "url": "https://en.wikipedia.org/wiki/The_Computer_and_the_Brain",
+    "rating": 3,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Sources of Power: How People Make Decisions",
+    "status": "queued",
+    "author": "Gary Klein",
+    "category": "book",
+    "year": 1998,
+    "url": "https://www.amazon.com/Sources-Power-People-Make-Decisions/dp/0262611465",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Maria Goeppert Mayer - Biographical",
+    "status": "queued",
+    "category": "article",
+    "url": "https://www.nobelprize.org/prizes/physics/1963/mayer/biographical/",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "What Caused The Explosion That Crippled Apollo 13?",
+    "url": "https://youtu.be/eO19LTJZM6c",
+    "recommended_by": []
+  },
+  {
+    "checked": true,
+    "status": "queued",
+    "title": "Astro tools",
+    "url": "https://twitter.com/daraobriain/status/1249440589327798272?s=09",
+    "recommended_by": []
+  },
+  {
+    "author": "Eliezer Yudkowsky",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JOR",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Harry Potter and the Methods of Rationality",
+    "url": "https://en.wikipedia.org/wiki/Harry_Potter_and_the_Methods_of_Rationality",
+    "year": 2010
+  },
+  {
+    "author": "K.J. Parker",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JOR"
+    ],
+    "status": "queued",
+    "title": "Sixteen Ways to Defend a Walled City",
+    "url": "https://www.goodreads.com/book/show/37946419-sixteen-ways-to-defend-a-walled-city",
+    "year": 2019
+  },
+  {
+    "checked": true,
+    "status": "queued",
+    "title": "Scrapeme-Andressen",
+    "url": "https://twitter.com/pmarca/status/1251634412334141440?s=09",
+    "recommended_by": []
+  },
+  {
+    "author": "Atul Gawande",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "The Checklist Manifesto",
+    "url": "https://en.wikipedia.org/wiki/The_Checklist_Manifesto",
+    "year": 2009,
+    "recommended_by": []
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "DE"
+    ],
+    "status": "queued",
+    "title": "Uncharted: The Nathan Drake Collection",
+    "url": "https://en.wikipedia.org/wiki/Uncharted:_The_Nathan_Drake_Collection",
+    "year": 2015
+  },
+  {
+    "author": "Herman Melville",
+    "category": "book",
+    "checked": true,
+    "rating": 5,
+    "recommended_by": [
+      "BF"
+    ],
+    "status": "done",
+    "title": "Moby-Dick",
+    "url": "https://en.wikipedia.org/wiki/Moby-Dick",
+    "year": 1851
+  },
+  {
+    "author": "Nolen Gertz",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NF"
+    ],
+    "status": "queued",
+    "title": "Nihilism and Technology",
+    "url": "https://www.goodreads.com/book/show/39844731-nihilism-and-technology",
+    "year": 2018
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Joel Coen",
+    "recommended_by": [
+      "JOR"
+    ],
+    "status": "queued",
+    "title": "The Hudsucker Proxy",
+    "url": "https://en.wikipedia.org/wiki/The_Hudsucker_Proxy",
+    "year": 1994
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "rating": 5,
+    "status": "done",
+    "title": "I Don't Know, Timmy, Being God Is a Big Responsibility",
+    "url": "https://qntm.org/responsibility",
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "done",
+    "title": "Ra",
+    "url": "https://qntm.org/ra",
+    "year": 2014,
+    "recommended_by": [
+      "NR"
+    ],
+    "rating": 5
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Jim Abrahams, David Zucker, Jerry Zucker",
+    "recommended_by": [
+      "BF"
+    ],
+    "status": "queued",
+    "title": "Top Secret!",
+    "url": "https://en.wikipedia.org/wiki/Top_Secret!",
+    "year": 1984
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Anthony B. Powell",
+    "recommended_by": [
+      "TG"
+    ],
+    "status": "queued",
+    "title": "Antarctica: A Year on Ice",
+    "url": "https://en.wikipedia.org/wiki/Antarctica:_A_Year_on_Ice",
+    "year": 2013
+  },
+  {
+    "author": "Sinclair Lewis",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NST"
+    ],
+    "status": "queued",
+    "title": "It Can't Happen Here",
+    "url": "https://en.wikipedia.org/wiki/It_Can%27t_Happen_Here",
+    "year": 1935
+  },
+  {
+    "category": "article",
+    "checked": true,
+    "status": "queued",
+    "title": "The Observer Effect – Marc Andreessen",
+    "url": "https://www.theobservereffect.org/marc.html",
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "Program for the International Assessment of Adult Competencies (PIAAC) U.S. 2017 Sample Public-use File (PUF)",
+    "url": "https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2020222",
+    "recommended_by": []
+  },
+  {
+    "category": "podcast",
+    "checked": true,
+    "status": "queued",
+    "title": "SEDScast",
+    "url": "https://seds.org/sedscast/",
+    "recommended_by": []
+  },
+  {
+    "author": "Peter Seibel",
+    "category": "article",
+    "checked": true,
+    "status": "queued",
+    "title": "Let a 1,000 flowers bloom. Then rip 999 of them out by the roots.",
+    "url": "http://gigamonkeys.com/flowers/",
+    "year": 2015,
+    "recommended_by": []
+  },
+  {
+    "title": "ASAT Tests Reading",
+    "category": "article",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "url": "https://twitter.com/brianweeden/status/1276127060268810241?s=09",
+    "checked": true
+  },
+  {
+    "title": "War in Space",
+    "category": "topic",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "url": "https://twitter.com/bleddb/status/1277889227070623744?s=09",
+    "checked": true
+  },
+  {
+    "title": "open satellite",
+    "category": "topic",
+    "status": "queued",
+    "url": "https://twitter.com/ea4gpz/status/1279163481539952642?s=09",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "3blue1brown streaming notes",
+    "category": "topic",
+    "status": "queued",
+    "url": "https://twitter.com/3blue1brown/status/1280992732345806848?s=09",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Charlie Songhurst – Lessons from Investing in 483 Companies – [Invest Like the Best, EP.181]",
+    "category": "podcast",
+    "status": "queued",
+    "year": 2020,
+    "url": "http://investorfieldguide.com/songhurst/",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Midnight Gospel",
+    "category": "tv",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "CD"
+    ],
+    "year": 2020,
+    "director": "Pendleton Ward",
+    "url": "https://en.wikipedia.org/wiki/The_Midnight_Gospel",
+    "checked": true
+  },
+  {
+    "title": "Nyt on lithium",
+    "category": "article",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Good Ancestor",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Roman Krznaric",
+    "year": 2020,
+    "url": "https://www.romankrznaric.com/good-ancestor",
+    "checked": true
+  },
+  {
+    "title": "Video Games and the Future of Education",
+    "status": "queued",
+    "url": "https://youtu.be/qWFScmtiC44",
+    "category": "other",
+    "year": 2020,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Two Years Before the Mast",
+    "status": "queued",
+    "recommended_by": [
+      "IC"
+    ],
+    "category": "book",
+    "author": "Richard Henry Dana Jr.",
+    "year": 1840,
+    "url": "https://en.wikipedia.org/wiki/Two_Years_Before_the_Mast",
+    "checked": true
+  },
+  {
+    "title": "The Kiss Quotient",
+    "status": "queued",
+    "recommended_by": [
+      "IC"
+    ],
+    "category": "book",
+    "author": "Helen Hoang",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/The_Kiss_Quotient",
+    "checked": true
+  },
+  {
+    "title": "Too Much and Never Enough: How My Family Created the World's Most Dangerous Man",
+    "status": "done",
+    "category": "book",
+    "author": "Mary L. Trump",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Too_Much_and_Never_Enough",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "title": "The Bit Player",
+    "status": "queued",
+    "url": "https://en.wikipedia.org/wiki/The_Bit_Player",
+    "checked": true,
+    "category": "movie",
+    "director": "Mark Levinson",
+    "year": 2019,
+    "recommended_by": []
+  },
+  {
+    "title": "The Under Presents",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "AMC"
+    ],
+    "url": "https://en.wikipedia.org/wiki/The_Under_Presents",
+    "year": 2019,
+    "checked": true
+  },
+  {
+    "title": "Neal Stephenson at The Interval at Long Now | San Francisco",
+    "status": "queued",
+    "url": "https://theinterval.org/salon-talks/02019/jun/06/neal-stephenson-fall",
+    "category": "other",
+    "year": 2019,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Knowledge Fight",
+    "category": "podcast",
+    "status": "queued",
+    "recommended_by": [
+      "MTM"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Knowledge_Fight",
+    "year": 2017,
+    "checked": true
+  },
+  {
+    "title": "Bundyville",
+    "status": "queued",
+    "category": "podcast",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Bundyville",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "astrophoto tools set",
+    "status": "queued",
+    "url": "https://twitter.com/AJamesMcCarthy/status/1299052245175001088?s=09",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "ANIMA",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "CB"
+    ],
+    "director": "Paul Thomas Anderson",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Anima_(Thom_Yorke_album)",
+    "checked": true
+  },
+  {
+    "title": "Happy People: A Year in the Taiga",
+    "category": "movie",
+    "status": "done",
+    "author": "Werner Herzog",
+    "director": "Werner Herzog",
+    "year": 2010,
+    "rating": 5,
+    "recommended_by": [
+      "DA"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Happy_People:_A_Year_in_the_Taiga",
+    "checked": true
+  },
+  {
+    "title": "Knives Out",
+    "category": "movie",
+    "status": "queued",
+    "director": "Rian Johnson",
+    "year": 2019,
+    "recommended_by": [
+      "BMB",
+      "EAI"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Knives_Out",
+    "checked": true
+  },
+  {
+    "title": "Monsters exhibition",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JBL"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Ascent of Money",
+    "category": "book",
+    "status": "queued",
+    "author": "Niall Ferguson",
+    "year": 2008,
+    "recommended_by": [
+      "VK"
+    ],
+    "url": "https://en.wikipedia.org/wiki/The_Ascent_of_Money",
+    "checked": true
+  },
+  {
+    "title": "Medici: Godfathers of the Renaissance",
+    "category": "tv",
+    "status": "queued",
+    "year": 2004,
+    "recommended_by": [
+      "SK"
+    ],
+    "url": "https://youtu.be/GOAVRcI6mFU",
+    "checked": true
+  },
+  {
+    "title": "All the Birds in the Sky",
+    "category": "book",
+    "status": "done",
+    "author": "Charlie Jane Anders",
+    "year": 2016,
+    "recommended_by": [
+      "ANY",
+      "MI",
+      "IC"
+    ],
+    "url": "https://en.wikipedia.org/wiki/All_the_Birds_in_the_Sky",
+    "checked": true,
+    "rating": 4
+  },
+  {
+    "title": "Idaho nuclear reactor tour",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "IC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Storm Before the Calm",
+    "category": "book",
+    "status": "queued",
+    "author": "George Friedman",
+    "year": 2020,
+    "recommended_by": [
+      "JU"
+    ],
+    "url": "https://en.wikipedia.org/wiki/The_Storm_Before_the_Calm",
+    "checked": true
+  },
+  {
+    "title": "Get Together",
+    "category": "book",
+    "status": "queued",
+    "author": "Bailey Richardson, Kevin Huynh, Kai Elmer Sotto",
+    "year": 2019,
+    "recommended_by": [
+      "TW"
+    ],
+    "url": "https://twitter.com/ljxie/status/1313265177647742978?s=09",
+    "checked": true
+  },
+  {
+    "title": "High-resolution solar imaging for citizen science | EPJ Web of Conferences",
+    "category": "article",
+    "status": "queued",
+    "author": "Alfred Yong Liang Tan",
+    "year": 2020,
+    "url": "https://www.epj-conferences.org/articles/epjconf/abs/2020/16/epjconf_seaan2020_01002/epjconf_seaan2020_01002.html",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "author": "Annie Duke",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Thinking in Bets",
+    "url": "https://en.wikipedia.org/wiki/Annie_Duke",
+    "year": 2018
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Robert Eggers",
+    "recommended_by": [
+      "BF"
+    ],
+    "status": "queued",
+    "title": "The Lighthouse",
+    "url": "https://en.wikipedia.org/wiki/The_Lighthouse_(2019_film)",
+    "year": 2019
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Robert Eggers",
+    "recommended_by": [
+      "BF"
+    ],
+    "status": "queued",
+    "title": "The Witch",
+    "url": "https://en.wikipedia.org/wiki/The_Witch_(2015_film)",
+    "year": 2015
+  },
+  {
+    "author": "Lindsay C. Gibson",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "Rando(unknown)",
+      "JWE",
+      "MEA"
+    ],
+    "status": "done",
+    "title": "Adult Children of Emotionally Immature Parents",
+    "url": "https://www.goodreads.com/book/show/23129659-adult-children-of-emotionally-immature-parents",
+    "year": 2015,
+    "rating": 5
+  },
+  {
+    "author": "Craig Clevenger",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "SH"
+    ],
+    "status": "queued",
+    "title": "The Contortionist's Handbook",
+    "url": "https://en.wikipedia.org/wiki/The_Contortionist%27s_Handbook",
+    "year": 2002
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "Dark and Quiet Skies for Science and Society",
+    "url": "https://www.youtube.com/playlist?list=PLaOqa4cng0GFqc1epTy3XTInKqoLjVqlS",
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "Satellite Webinar?",
+    "url": "https://ibs.itu.int/arch/ITU-R/2020SatelileWebinars/vr-20201007-1500-fl.mp4",
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "done",
+    "title": "Steve Jurvetson Talk on Satellite Innovation",
+    "url": "https://vimeo.com/465512979/ed18ea2087?s=09",
+    "year": 2020,
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "Crime Pays But Botany Doesn't",
+    "url": "https://en.wikipedia.org/wiki/Joey_Santore",
+    "recommended_by": []
+  },
+  {
+    "author": "Philip C. D. Hobbs",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "ALV"
+    ],
+    "status": "queued",
+    "title": "Building Electro-Optical Systems: Making It All Work",
+    "url": "https://www.goodreads.com/book/show/808472.Building_Electro_Optical_Systems",
+    "year": 2000
+  },
+  {
+    "title": "The Thing",
+    "category": "movie",
+    "status": "queued",
+    "director": "John Carpenter",
+    "year": 1982,
+    "url": "https://en.wikipedia.org/wiki/The_Thing_(1982_film)",
+    "recommended_by": [
+      "ALV"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Jeeves and Wooster",
+    "category": "book",
+    "status": "queued",
+    "author": "P.G. Wodehouse",
+    "url": "https://en.wikipedia.org/wiki/Jeeves",
+    "recommended_by": [
+      "RM"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Computer's Voice",
+    "category": "book",
+    "status": "queued",
+    "author": "Liz W. Faber",
+    "year": 2020,
+    "url": "https://twitter.com/LizWFab/status/1316109518925856768?s=09",
+    "recommended_by": [
+      "TW"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Gulag Archipelago",
+    "category": "book",
+    "status": "queued",
+    "author": "Aleksandr Solzhenitsyn",
+    "year": 1973,
+    "url": "https://en.wikipedia.org/wiki/The_Gulag_Archipelago",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Hunt for Planet Nine",
+    "status": "queued",
+    "url": "https://longreads.com/2019/01/22/the-hunt-for-planet-nine/",
+    "checked": true,
+    "category": "article",
+    "year": 2019,
+    "recommended_by": []
+  },
+  {
+    "title": "Azure Space launch highlights",
+    "category": "other",
+    "status": "queued",
+    "url": "https://youtu.be/6h52JPnDpmA",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Advantage",
+    "category": "book",
+    "status": "done",
+    "author": "Patrick Lencioni",
+    "year": 2012,
+    "recommended_by": [
+      "WKZ"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "Tightrope",
+    "category": "book",
+    "status": "queued",
+    "author": "Nicholas Kristof and Sheryl WuDunn",
+    "year": 2020,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "13",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Hero with a Thousand Faces",
+    "category": "book",
+    "status": "done",
+    "author": "Joseph Campbell",
+    "year": 1949,
+    "url": "https://en.wikipedia.org/wiki/The_Hero_with_a_Thousand_Faces",
+    "recommended_by": [
+      "AMC",
+      "MF",
+      "WKZ"
+    ],
+    "checked": true,
+    "rating": 4
+  },
+  {
+    "title": "With Feet of Clay",
+    "category": "book",
+    "status": "done",
+    "author": "Robert J. Luidens",
+    "year": 2024,
+    "url": "https://www.amazon.com/Feet-Clay-Pastoral-Confession-Memoir/dp/B0D5LHWFGD",
+    "checked": true,
+    "recommended_by": [],
+    "rating": 1
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "status": "queued",
+    "title": "Opus Magnum",
+    "url": "https://en.wikipedia.org/wiki/Opus_Magnum",
+    "year": 2017,
+    "recommended_by": []
+  },
+  {
+    "author": "Egan",
+    "category": "movie",
+    "checked": true,
+    "director": "Makoto Shinkai",
+    "status": "queued",
+    "title": "Your Name",
+    "url": "https://en.wikipedia.org/wiki/Your_Name",
+    "year": 2016,
+    "recommended_by": []
+  },
+  {
+    "checked": true,
+    "status": "queued",
+    "title": "Scrapeme talk on space lasers",
+    "url": "https://www.satellitetoday.com/podcast/2020/11/23/from-launch-dreams-to-laser-beams-with-tina-ghataore-of-mynaric/?s=09",
+    "recommended_by": []
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "status": "queued",
+    "title": "The tube guys",
+    "recommended_by": []
+  },
+  {
+    "author": "Ichiro Kishimi and Fumitake Koga",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "MA",
+      "JBL"
+    ],
+    "status": "queued",
+    "title": "The Courage to Be Disliked",
+    "url": "https://en.wikipedia.org/wiki/The_Courage_to_Be_Disliked",
+    "year": 2013
+  },
+  {
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "Prosperity gospel of sv",
+    "recommended_by": []
+  },
+  {
+    "author": "William Leonard Pickard",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "The Rose of Paracelsus",
+    "url": "https://en.wikipedia.org/wiki/The_Rose_of_Paracelsus",
+    "year": 2015
+  },
+  {
+    "author": "Arthur C. Clarke",
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "The Nine Billion Names of God",
+    "url": "https://en.wikipedia.org/wiki/The_Nine_Billion_Names_of_God",
+    "year": 1953
+  },
+  {
+    "category": "podcast",
+    "checked": true,
+    "status": "queued",
+    "title": "China and the US with Tobita Chow and Jake Werner",
+    "url": "https://open.spotify.com/episode/2EIxhEd29aSrQ03Fm0eeJF?si=1fJ-j-6lRQGgiqa85d38Bg",
+    "year": 2020,
+    "recommended_by": []
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "John Carmack — WaitWho.is",
+    "url": "https://waitwho.is/john-carmack/essays",
+    "recommended_by": []
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Byron Ross Chudnow",
+    "status": "queued",
+    "title": "The Doberman Gang",
+    "url": "https://en.wikipedia.org/wiki/The_Doberman_Gang",
+    "year": 1972,
+    "recommended_by": []
+  },
+  {
+    "author": "Eric Evans",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JWE"
+    ],
+    "status": "queued",
+    "title": "Domain-Driven Design: Tackling Complexity in the Heart of Software",
+    "url": "https://en.wikipedia.org/wiki/Domain-driven_design",
+    "year": 2003
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Lars von Trier",
+    "recommended_by": [
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Melancholia",
+    "url": "https://en.wikipedia.org/wiki/Melancholia_(2011_film)",
+    "year": 2011
+  },
+  {
+    "author": "José Saramago",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Death with Interruptions",
+    "url": "https://en.wikipedia.org/wiki/Death_with_Interruptions",
+    "year": 2005
+  },
+  {
+    "author": "Haruki Murakami",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "IG",
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "What I Talk About When I Talk About Running",
+    "url": "https://en.wikipedia.org/wiki/What_I_Talk_About_When_I_Talk_About_Running",
+    "year": 2007
+  },
+  {
+    "author": "Yōko Ogawa",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "The Memory Police",
+    "url": "https://en.wikipedia.org/wiki/The_Memory_Police",
+    "year": 1994
+  },
+  {
+    "author": "China Miéville",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "The City & the City",
+    "url": "https://en.wikipedia.org/wiki/The_City_%26_the_City",
+    "year": 2009
+  },
+  {
+    "author": "China Miéville",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Perdido Street Station",
+    "url": "https://en.wikipedia.org/wiki/Perdido_Street_Station",
+    "year": 2000
+  },
+  {
+    "author": "Yoon Ha Lee",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Machineries of Empire",
+    "url": "https://en.wikipedia.org/wiki/Machineries_of_Empire",
+    "year": 2016
+  },
+  {
+    "author": "Ken Liu",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "The Paper Menagerie and Other Stories",
+    "url": "https://en.wikipedia.org/wiki/The_Paper_Menagerie",
+    "year": 2016
+  },
+  {
+    "title": "Gideon the Ninth",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EK",
+      "KKE",
+      "LLE",
+      "SB",
+      "UN"
+    ],
+    "author": "Tamsyn Muir",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Gideon_the_Ninth",
+    "checked": true
+  },
+  {
+    "title": "Gemma Arrowsmith: Everything I know about writing, I learned from sketch comedy",
+    "category": "article",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "url": "https://www.comedy.co.uk/pro/inside_track/gemma-arrowsmith-on-sketch-writing/",
+    "checked": true
+  },
+  {
+    "title": "Gorogoa",
+    "category": "game",
+    "status": "queued",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Gorogoa",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Passfire",
+    "category": "movie",
+    "status": "queued",
+    "director": "Jeremy Veverka, Jesse Veverka",
+    "year": 2016,
+    "url": "https://www.imdb.com/title/tt2536884/",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Bridge",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EAI"
+    ],
+    "author": "Iain Banks",
+    "year": 1986,
+    "url": "https://en.wikipedia.org/wiki/The_Bridge_(Banks_novel)",
+    "checked": true
+  },
+  {
+    "title": "Paul Graham on Twitter: \"Since it's World Book Day, here are some of the best books I've read recently: I Want to be a Mathematician, by Paul Halmos Barbarian Days, by William Finnegan From Galileo to Newton, by Rupert Hall The British Industrial Revolution in Global Perspective, by Robert Allen\" / Twitter",
+    "category": "article",
+    "status": "queued",
+    "url": "https://twitter.com/paulg/status/1367463461425414159",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Space Policy Edition: SpaceX's Early, Desperate Days (with Eric Berger)",
+    "category": "podcast",
+    "status": "queued",
+    "url": "https://www.planetary.org/planetary-radio/0305-2021-spe-eric-berger",
+    "year": 2021,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Hades",
+    "category": "game",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "ALV"
+    ],
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Hades_(video_game)",
+    "checked": true
+  },
+  {
+    "title": "Sundiver",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CL"
+    ],
+    "author": "David Brin",
+    "year": 1980,
+    "url": "https://en.wikipedia.org/wiki/Sundiver",
+    "checked": true
+  },
+  {
+    "title": "Hiring Smart!",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "KK"
+    ],
+    "author": "Pierre Mornell",
+    "year": 1998,
+    "url": "https://www.penguinrandomhouse.com/books/197690/hiring-smart-by-pierre-mornell/",
+    "checked": true
+  },
+  {
+    "author": "Stewart Brand",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "KK",
+      "UN"
+    ],
+    "status": "queued",
+    "title": "How Buildings Learn",
+    "url": "https://en.wikipedia.org/wiki/How_Buildings_Learn",
+    "year": 1994
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "recommended_by": [
+      "JE"
+    ],
+    "status": "queued",
+    "title": "Video about thoe"
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "MKI",
+      "AF"
+    ],
+    "status": "queued",
+    "title": "Mike Judge Presents: Tales from the Tour Bus",
+    "url": "https://en.wikipedia.org/wiki/Mike_Judge_Presents:_Tales_from_the_Tour_Bus",
+    "year": 2017
+  },
+  {
+    "author": "David Bradford and Carole Robin",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NFX"
+    ],
+    "status": "queued",
+    "title": "Connect: Building Exceptional Relationships with Family, Friends, and Colleagues",
+    "url": "https://www.penguinrandomhouse.com/books/645809/connect-by-david-bradford-and-carole-robin/",
+    "year": 2021
+  },
+  {
+    "author": "Neil Gaiman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "SB"
+    ],
+    "status": "queued",
+    "title": "Smoke and Mirrors",
+    "url": "https://en.wikipedia.org/wiki/Smoke_and_Mirrors_(Gaiman_book)",
+    "year": 1998
+  },
+  {
+    "author": "Neil Gaiman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "SB"
+    ],
+    "status": "queued",
+    "title": "The Graveyard Book",
+    "url": "https://en.wikipedia.org/wiki/The_Graveyard_Book",
+    "year": 2008
+  },
+  {
+    "author": "Neil Gaiman",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "Fragile Things",
+    "url": "https://en.wikipedia.org/wiki/Fragile_Things",
+    "year": 2006,
+    "recommended_by": []
+  },
+  {
+    "author": "Neil Gaiman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "SB"
+    ],
+    "status": "queued",
+    "title": "The Truth Is a Cave in the Black Mountains",
+    "url": "https://www.neilgaiman.com/works/Books/The+Truth+Is+a+Cave+in+the+Black+Mountains/",
+    "year": 2010
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Joe Penna",
+    "recommended_by": [
+      "SMA"
+    ],
+    "status": "queued",
+    "title": "Stowaway",
+    "url": "https://en.wikipedia.org/wiki/Stowaway_(2021_film)",
+    "year": 2021
+  },
+  {
+    "author": "Kazuo Ishiguro",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AP",
+      "MC",
+      "MF",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "The Remains of the Day",
+    "url": "https://en.wikipedia.org/wiki/The_Remains_of_the_Day",
+    "year": 1989
+  },
+  {
+    "title": "The Left Hand of Darkness",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC",
+      "AP",
+      "MF",
+      "SA"
+    ],
+    "author": "Ursula K. Le Guin",
+    "year": 1969,
+    "url": "https://en.wikipedia.org/wiki/The_Left_Hand_of_Darkness",
+    "checked": true
+  },
+  {
+    "title": "Tesla",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "PGR"
+    ],
+    "director": "Michael Almereyda",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Tesla_(2020_film)",
+    "checked": true
+  },
+  {
+    "title": "Bad Lieutenant",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "director": "Abel Ferrara",
+    "year": 1992,
+    "url": "https://en.wikipedia.org/wiki/Bad_Lieutenant",
+    "checked": true
+  },
+  {
+    "title": "Valheim",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "TK"
+    ],
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Valheim",
+    "checked": true
+  },
+  {
+    "title": "The Ministry for the Future",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "recommended_by": [
+      "BA",
+      "GHS",
+      "LLE",
+      "MMC"
+    ],
+    "author": "Kim Stanley Robinson",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Ministry_for_the_Future",
+    "checked": true
+  },
+  {
+    "title": "Reply All",
+    "category": "podcast",
+    "status": "queued",
+    "url": "https://gimletmedia.com/shows/reply-all/llhe5nm",
+    "year": 2014,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Last Stargazers",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Emily Levesque",
+    "year": 2020,
+    "url": "https://www.goodreads.com/book/show/44024316-the-last-stargazers",
+    "checked": true
+  },
+  {
+    "title": "Ted Lasso",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "BJ"
+    ],
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Ted_Lasso",
+    "checked": true
+  },
+  {
+    "title": "Steven Universe",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "BJ"
+    ],
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Steven_Universe",
+    "checked": true
+  },
+  {
+    "title": "Republic of Lies",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Anna Merlan",
+    "year": 2019,
+    "url": "https://www.goodreads.com/book/show/40046060-republic-of-lies",
+    "checked": true
+  },
+  {
+    "title": "Nomadland",
+    "category": "movie",
+    "status": "done",
+    "recommended_by": [
+      "ALE",
+      "CN",
+      "CD",
+      "UN"
+    ],
+    "director": "Chloé Zhao",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Nomadland",
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "Making Great Choices",
+    "status": "queued",
+    "recommended_by": [
+      "SK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Win Without Pitching Manifesto",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SK"
+    ],
+    "author": "Blair Enns",
+    "year": 2010,
+    "url": "https://www.winwithoutpitching.com/books/the-win-without-pitching-manifesto/",
+    "checked": true
+  },
+  {
+    "title": "The Fifth Season",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AW",
+      "LBH",
+      "SK"
+    ],
+    "author": "N. K. Jemisin",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/The_Fifth_Season_(novel)",
+    "checked": true
+  },
+  {
+    "title": "Debt of Honor",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DPO"
+    ],
+    "author": "Tom Clancy",
+    "year": 1994,
+    "url": "https://en.wikipedia.org/wiki/Debt_of_Honor",
+    "checked": true
+  },
+  {
+    "title": "Red Storm Rising",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DPO"
+    ],
+    "author": "Tom Clancy",
+    "year": 1986,
+    "url": "https://en.wikipedia.org/wiki/Red_Storm_Rising",
+    "checked": true
+  },
+  {
+    "title": "Bombshell",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "DPO",
+      "MMA"
+    ],
+    "director": "Jay Roach",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Bombshell_(2019_film)",
+    "checked": true
+  },
+  {
+    "title": "Sufferfest",
+    "category": "movie",
+    "status": "queued",
+    "director": "Cedar Wright",
+    "year": 2013,
+    "url": "https://www.climbing.com/videos/the-sufferfest-with-alex-honnold-and-cedar-wright-full-movie/",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Heaven's Design Team",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "SN"
+    ],
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Heaven%27s_Design_Team",
+    "checked": true
+  },
+  {
+    "title": "The Revolutionary Genius of Plants",
+    "category": "book",
+    "status": "done",
+    "rating": 3,
+    "recommended_by": [
+      "CD"
+    ],
+    "author": "Stefano Mancuso",
+    "year": 2018,
+    "url": "https://www.simonandschuster.com/books/The-Revolutionary-Genius-of-Plants/Stefano-Mancuso/9781501187858",
+    "checked": true
+  },
+  {
+    "title": "Meru",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MGR"
+    ],
+    "director": "Jimmy Chin, Elizabeth Chai Vasarhelyi",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Meru_(film)",
+    "checked": true
+  },
+  {
+    "title": "Hail Satan?",
+    "category": "movie",
+    "status": "done",
+    "recommended_by": [
+      "HR",
+      "MKI",
+      "AF",
+      "LB"
+    ],
+    "director": "Penny Lane",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Hail_Satan%3F",
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "Q: Into the Storm",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "MH"
+    ],
+    "director": "Cullen Hoback",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Q_Into_the_Storm",
+    "checked": true
+  },
+  {
+    "title": "Wild Wild Country",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "HR"
+    ],
+    "director": "Chapman Way, Maclain Way",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Wild_Wild_Country",
+    "checked": true
+  },
+  {
+    "title": "The Art of Asking",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HR"
+    ],
+    "author": "Amanda Palmer",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/The_Art_of_Asking",
+    "checked": true
+  },
+  {
+    "title": "Confessions of a Sociopath",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HR"
+    ],
+    "author": "M.E. Thomas",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Confessions_of_a_Sociopath",
+    "checked": true
+  },
+  {
+    "title": "Stray",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "HR"
+    ],
+    "director": "Elizabeth Lo",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Stray_(2021_film)",
+    "checked": true
+  },
+  {
+    "title": "Behind the Curve",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "HR",
+      "ACT"
+    ],
+    "director": "Daniel J. Clark",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Behind_the_Curve",
+    "checked": true
+  },
+  {
+    "title": "Augmenting Human Intellect: A Conceptual Framework",
+    "category": "article",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Douglas Engelbart",
+    "year": 1962,
+    "url": "https://www.dougengelbart.org/pubs/augment-3906.html",
+    "checked": true
+  },
+  {
+    "title": "As We May Think",
+    "category": "article",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Vannevar Bush",
+    "year": 1945,
+    "url": "https://en.wikipedia.org/wiki/As_We_May_Think",
+    "checked": true
+  },
+  {
+    "author": "Seymour Papert",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Mindstorms: Children, Computers, and Powerful Ideas",
+    "url": "https://en.wikipedia.org/wiki/Mindstorms_(book)",
+    "year": 1980
+  },
+  {
+    "author": "Bret Victor",
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "HR",
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Inventing on Principle",
+    "url": "https://vimeo.com/36579366",
+    "year": 2012
+  },
+  {
+    "author": "Lucy Suchman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Plans and Situated Actions: The Problem of Human-Machine Communication",
+    "url": "https://en.wikipedia.org/wiki/Plans_and_Situated_Actions",
+    "year": 1987
+  },
+  {
+    "author": "Greg Egan",
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "The Safe-Deposit Box",
+    "url": "https://en.wikipedia.org/wiki/The_Safe-Deposit_Box",
+    "year": 1990
+  },
+  {
+    "author": "Jiddu Krishnamurti",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "Freedom from the Known",
+    "url": "https://en.wikipedia.org/wiki/Freedom_from_the_Known",
+    "year": 1969
+  },
+  {
+    "author": "Jiddu Krishnamurti",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "Total Freedom: The Essential Krishnamurti",
+    "year": 1996
+  },
+  {
+    "author": "Osho",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "The Great Challenge",
+    "year": 1982
+  },
+  {
+    "author": "Jiddu Krishnamurti",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "The Book of Life: Daily Meditations with Krishnamurti",
+    "year": 1995
+  },
+  {
+    "author": "Jiddu Krishnamurti",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "Think on These Things",
+    "year": 1964
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Ian Cheney",
+    "recommended_by": [
+      "MEA",
+      "IC"
+    ],
+    "status": "queued",
+    "title": "The Search for General Tso",
+    "url": "https://en.wikipedia.org/wiki/The_Search_for_General_Tso",
+    "year": 2014
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "SK"
+    ],
+    "status": "queued",
+    "title": "Brethe"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Bryan Fogel",
+    "recommended_by": [
+      "EC",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Icarus",
+    "url": "https://en.wikipedia.org/wiki/Icarus_(2017_film)",
+    "year": 2017
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "rating": 4,
+    "status": "done",
+    "title": "Love, Death & Robots",
+    "url": "https://en.wikipedia.org/wiki/Love,_Death_%26_Robots",
+    "year": 2019,
+    "recommended_by": []
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "JCO"
+    ],
+    "status": "queued",
+    "title": "Vulcan"
+  },
+  {
+    "author": "Simon Winchester",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JC"
+    ],
+    "status": "queued",
+    "title": "The Perfectionists: How Precision Engineers Created the Modern World",
+    "url": "https://www.goodreads.com/book/show/35068671-the-perfectionists",
+    "year": 2018
+  },
+  {
+    "author": "Brian D. Earp, Julian Savulescu",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MMA"
+    ],
+    "status": "queued",
+    "title": "Love Drugs: The Chemical Future of Relationships",
+    "url": "https://en.wikipedia.org/wiki/Love_Drugs",
+    "year": 2020
+  },
+  {
+    "category": "article",
+    "checked": true,
+    "recommended_by": [
+      "BJ"
+    ],
+    "status": "queued",
+    "title": "Economist on Identity"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Emerald Fennell",
+    "recommended_by": [
+      "BJ"
+    ],
+    "status": "queued",
+    "title": "Promising Young Woman",
+    "url": "https://en.wikipedia.org/wiki/Promising_Young_Woman",
+    "year": 2020
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "RI"
+    ],
+    "status": "queued",
+    "title": "Madam Secretary",
+    "url": "https://en.wikipedia.org/wiki/Madam_Secretary_(TV_series)",
+    "year": 2014
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Jake Kasdan",
+    "recommended_by": [
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Walk Hard: The Dewey Cox Story",
+    "url": "https://en.wikipedia.org/wiki/Walk_Hard:_The_Dewey_Cox_Story",
+    "year": 2007
+  },
+  {
+    "title": "The Last Black Man in San Francisco",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MK",
+      "RON"
+    ],
+    "director": "Joe Talbot",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/The_Last_Black_Man_in_San_Francisco",
+    "checked": true
+  },
+  {
+    "title": "A Simple Favor",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "director": "Paul Feig",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/A_Simple_Favor_(film)",
+    "checked": true
+  },
+  {
+    "title": "The Vow",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "BE"
+    ],
+    "notes": "(Nexium Documentary)",
+    "director": "Jehane Noujaim, Karim Amer",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Vow_(TV_series)",
+    "checked": true
+  },
+  {
+    "title": "The Disaster Artist",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "AME",
+      "GMO",
+      "JWE"
+    ],
+    "director": "James Franco",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/The_Disaster_Artist_(film)",
+    "checked": true
+  },
+  {
+    "title": "How the world changed",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HP"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Scene of Change: A Lifetime in American Science",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HP"
+    ],
+    "author": "Warren Weaver",
+    "year": 1970,
+    "url": "https://en.wikipedia.org/wiki/Warren_Weaver",
+    "checked": true
+  },
+  {
+    "title": "Atlas of AI",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DSO"
+    ],
+    "author": "Kate Crawford",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Atlas_of_AI",
+    "checked": true
+  },
+  {
+    "title": "Paradise is Lost",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Fermi Paradox Is Our Business Model",
+    "category": "other",
+    "status": "queued",
+    "recommended_by": [
+      "ATI"
+    ],
+    "author": "Charlie Jane Anders",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/The_Fermi_Paradox_Is_Our_Business_Model",
+    "checked": true
+  },
+  {
+    "title": "Kentucky Route Zero",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "DO"
+    ],
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Kentucky_Route_Zero",
+    "checked": true
+  },
+  {
+    "title": "Barb and Star Go to Vista Del Mar",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "GM"
+    ],
+    "director": "Josh Greenbaum",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Barb_and_Star_Go_to_Vista_Del_Mar",
+    "checked": true
+  },
+  {
+    "title": "Almost Famous",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "FW"
+    ],
+    "director": "Cameron Crowe",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/Almost_Famous",
+    "checked": true
+  },
+  {
+    "title": "MirrorMask",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "CKE"
+    ],
+    "director": "Dave McKean",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/MirrorMask",
+    "checked": true
+  },
+  {
+    "title": "Rice Boy",
+    "category": "book",
+    "status": "queued",
+    "author": "Evan Dahm",
+    "recommended_by": [
+      "AME"
+    ],
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Evan_Dahm",
+    "checked": true
+  },
+  {
+    "title": "Homestuck",
+    "category": "other",
+    "status": "queued",
+    "recommended_by": [
+      "AME"
+    ],
+    "author": "Andrew Hussie",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Homestuck",
+    "checked": true
+  },
+  {
+    "title": "Ticket to Ride",
+    "category": "game",
+    "status": "queued",
+    "year": 2004,
+    "url": "https://en.wikipedia.org/wiki/Ticket_to_Ride_(board_game)",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Rust",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "JMI"
+    ],
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Rust_(video_game)",
+    "checked": true
+  },
+  {
+    "title": "Fake Famous",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MEL"
+    ],
+    "director": "Nick Bilton",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Fake_Famous",
+    "checked": true
+  },
+  {
+    "title": "Centaurworld",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "MEL"
+    ],
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Centaurworld",
+    "checked": true
+  },
+  {
+    "title": "You're the Worst",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "MEL"
+    ],
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/You%27re_the_Worst",
+    "checked": true
+  },
+  {
+    "title": "Bones Brigade: An Autobiography",
+    "category": "movie",
+    "status": "queued",
+    "director": "Stacy Peralta",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Bones_Brigade:_An_Autobiography",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Sat",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Rock Warrior's Way",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "OB"
+    ],
+    "author": "Arno Ilgner",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/The_Rock_Warrior%27s_Way",
+    "checked": true
+  },
+  {
+    "title": "Endurance: Shackleton's Incredible Voyage",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "MMC",
+      "PB"
+    ],
+    "author": "Alfred Lansing",
+    "year": 1959,
+    "url": "https://en.wikipedia.org/wiki/Endurance:_Shackleton%27s_Incredible_Voyage",
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "Command and Control: Nuclear Weapons, the Damascus Accident, and the Illusion of Safety",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MGR"
+    ],
+    "author": "Eric Schlosser",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Command_and_Control_(book)",
+    "checked": true
+  },
+  {
+    "title": "Aircraft Design: A Conceptual Approach",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CD"
+    ],
+    "author": "Daniel P. Raymer",
+    "year": 1989,
+    "url": "https://www.amazon.com/Aircraft-Design-Conceptual-Approach-Education/dp/1600869114",
+    "checked": true
+  },
+  {
+    "title": "nick p list",
+    "status": "queued",
+    "url": "https://twitter.com/NickPinkston/status/1432902753345363969?s=09",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Fantastic Fungi",
+    "category": "movie",
+    "status": "done",
+    "rating": 4,
+    "recommended_by": [
+      "SK"
+    ],
+    "director": "Louie Schwartzberg",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Fantastic_Fungi",
+    "checked": true
+  },
+  {
+    "title": "The Idea Factory: Bell Labs and the Great Age of American Innovation",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JCO",
+      "MKI",
+      "AF"
+    ],
+    "author": "Jon Gertner",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/The_Idea_Factory",
+    "checked": true
+  },
+  {
+    "title": "Nolan brothers movies",
+    "status": "queued",
+    "recommended_by": [
+      "AF"
+    ],
+    "checked": true
+  },
+  {
+    "author": "Richard C. Schwartz",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EB",
+      "MMA"
+    ],
+    "status": "queued",
+    "title": "No Bad Parts",
+    "url": "https://www.goodreads.com/book/show/55384168-no-bad-parts",
+    "year": 2021
+  },
+  {
+    "author": "Harold McGee",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "On Food and Cooking",
+    "url": "https://en.wikipedia.org/wiki/On_Food_and_Cooking",
+    "year": 1984,
+    "recommended_by": []
+  },
+  {
+    "author": "Anna Lembke",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "ALE"
+    ],
+    "status": "queued",
+    "title": "Dopamine Nation",
+    "url": "https://en.wikipedia.org/wiki/Anna_Lembke",
+    "year": 2021
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "Brian David Gilbert",
+    "url": "https://en.wikipedia.org/wiki/Brian_David_Gilbert"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Joel Coen",
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "O Brother, Where Art Thou?",
+    "url": "https://en.wikipedia.org/wiki/O_Brother,_Where_Art_Thou%3F",
+    "year": 2000
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "Jefferson Mays - A Christmas Carol",
+    "url": "https://www.geffenplayhouse.org/shows/charles-dickens-a-christmas-carol/",
+    "year": 2018
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "director": "Scott Frank",
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "The Queen's Gambit",
+    "url": "https://en.wikipedia.org/wiki/The_Queen%27s_Gambit_(miniseries)",
+    "year": 2020
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "LD"
+    ],
+    "status": "queued",
+    "title": "The Mystery of the Cocaine Mummies",
+    "url": "https://www.channel4.com/programmes/the-mystery-of-the-cocaine-mummies",
+    "year": 1996
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "MTM"
+    ],
+    "status": "queued",
+    "title": "Jean-Claude Van Johnson",
+    "url": "https://en.wikipedia.org/wiki/Jean-Claude_Van_Johnson",
+    "year": 2016
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Mabrouk El Mechri",
+    "recommended_by": [
+      "MTM"
+    ],
+    "status": "queued",
+    "title": "JCVD",
+    "url": "https://en.wikipedia.org/wiki/JCVD_(film)",
+    "year": 2008
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Roland Emmerich",
+    "recommended_by": [
+      "MTM"
+    ],
+    "status": "queued",
+    "title": "Universal Soldier",
+    "url": "https://en.wikipedia.org/wiki/Universal_Soldier_(1992_film)",
+    "year": 1992
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "ALV",
+      "MGR",
+      "RM"
+    ],
+    "status": "queued",
+    "title": "Loki",
+    "url": "https://en.wikipedia.org/wiki/Loki_(TV_series)",
+    "year": 2021
+  },
+  {
+    "author": "Amanda Montell",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EP"
+    ],
+    "status": "queued",
+    "title": "Cultish: The Language of Fanaticism",
+    "url": "https://en.wikipedia.org/wiki/Cultish",
+    "year": 2021
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "KAT"
+    ],
+    "status": "done",
+    "title": "Squid Game",
+    "url": "https://en.wikipedia.org/wiki/Squid_Game",
+    "year": 2021,
+    "rating": 4
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "status": "queued",
+    "title": "City Museum",
+    "url": "https://en.wikipedia.org/wiki/City_Museum_(St._Louis,_Missouri)",
+    "year": 1997,
+    "recommended_by": []
+  },
+  {
+    "author": "Ursula K. Le Guin",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF",
+      "FW",
+      "JWE"
+    ],
+    "status": "done",
+    "title": "The Dispossessed",
+    "url": "https://en.wikipedia.org/wiki/The_Dispossessed",
+    "year": 1974,
+    "rating": 5
+  },
+  {
+    "author": "Iceberg Slim",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "Pimp: The Story of My Life",
+    "url": "https://en.wikipedia.org/wiki/Iceberg_Slim",
+    "year": 1967
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "MTM"
+    ],
+    "status": "queued",
+    "title": "Abzû",
+    "url": "https://en.wikipedia.org/wiki/Abz%C3%BB",
+    "year": 2016
+  },
+  {
+    "author": "Andy Weir",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "KC",
+      "SK",
+      "AD",
+      "CY"
+    ],
+    "status": "queued",
+    "title": "Project Hail Mary",
+    "url": "https://en.wikipedia.org/wiki/Project_Hail_Mary",
+    "year": 2021
+  },
+  {
+    "author": "Linnea Sterte",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "Stages of Rot",
+    "url": "https://en.wikipedia.org/wiki/Linnea_Sterte",
+    "year": 2017
+  },
+  {
+    "title": "Real price of anything, The",
+    "category": "movie",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Magpie Murders",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EAI",
+      "TD"
+    ],
+    "author": "Anthony Horowitz",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Magpie_Murders",
+    "checked": true
+  },
+  {
+    "title": "Doug The Dog",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "TD"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Electric Dreams",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "TD",
+      "VK"
+    ],
+    "director": "Steve Barron",
+    "year": 1984,
+    "url": "https://en.wikipedia.org/wiki/Electric_Dreams_(film)",
+    "checked": true
+  },
+  {
+    "title": "Girl in Landscape",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AS"
+    ],
+    "author": "Jonathan Lethem",
+    "year": 1998,
+    "url": "https://en.wikipedia.org/wiki/Girl_in_Landscape",
+    "checked": true
+  },
+  {
+    "title": "The 4-Hour Workweek",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "PR"
+    ],
+    "author": "Timothy Ferriss",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/The_4-Hour_Workweek",
+    "checked": true
+  },
+  {
+    "title": "Creative Capital",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JCR"
+    ],
+    "author": "Spencer E. Ante",
+    "year": 2008,
+    "checked": true
+  },
+  {
+    "title": "Season of the Witch",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MH"
+    ],
+    "author": "David Talbot",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Season_of_the_Witch:_Enchantment,_Terror,_and_Deliverance_in_the_City_of_Love",
+    "checked": true
+  },
+  {
+    "title": "Bellingcat: Truth in a Post-Truth World",
+    "category": "movie",
+    "status": "queued",
+    "url": "https://en.wikipedia.org/wiki/Bellingcat:_Truth_in_a_Post-Truth_World",
+    "director": "Hans Pool",
+    "year": 2018,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Children of Time",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC",
+      "BMB",
+      "DSG",
+      "MP"
+    ],
+    "author": "Adrian Tchaikovsky",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Children_of_Time_(novel)",
+    "checked": true
+  },
+  {
+    "author": "Hank Green",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MP"
+    ],
+    "status": "queued",
+    "title": "An Absolutely Remarkable Thing",
+    "url": "https://en.wikipedia.org/wiki/An_Absolutely_Remarkable_Thing",
+    "year": 2018
+  },
+  {
+    "author": "Hank Green",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MP"
+    ],
+    "status": "queued",
+    "title": "A Beautifully Foolish Endeavor",
+    "url": "https://en.wikipedia.org/wiki/A_Beautifully_Foolish_Endeavor",
+    "year": 2020
+  },
+  {
+    "author": "Arthur Turrell",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "HP"
+    ],
+    "status": "queued",
+    "title": "The Star Builders",
+    "url": "https://www.goodreads.com/book/show/55711601-the-star-builders",
+    "year": 2021
+  },
+  {
+    "author": "Charles Stross",
+    "category": "book",
+    "checked": true,
+    "rating": 4,
+    "recommended_by": [
+      "MS"
+    ],
+    "status": "done",
+    "title": "Accelerando",
+    "url": "https://en.wikipedia.org/wiki/Accelerando",
+    "year": 2005
+  },
+  {
+    "author": "Roger Zelazny",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DO"
+    ],
+    "status": "queued",
+    "title": "A Night in the Lonesome October",
+    "url": "https://en.wikipedia.org/wiki/A_Night_in_the_Lonesome_October",
+    "year": 1993
+  },
+  {
+    "checked": true,
+    "status": "queued",
+    "title": "scrapeme",
+    "url": "https://twitter.com/tiffanee_dawn/status/1461199450257321988?t=TJdWfTT0XcnHPFQTweSIdQ&s=09",
+    "recommended_by": []
+  },
+  {
+    "author": "Michael Shellenberger",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JG"
+    ],
+    "status": "queued",
+    "title": "San Fransicko",
+    "url": "https://en.wikipedia.org/wiki/San_Fransicko",
+    "year": 2021
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Joe Dante",
+    "recommended_by": [
+      "TU"
+    ],
+    "status": "queued",
+    "title": "Innerspace",
+    "url": "https://en.wikipedia.org/wiki/Innerspace",
+    "year": 1987
+  },
+  {
+    "author": "Merlin Sheldrake",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JB"
+    ],
+    "status": "queued",
+    "title": "Entangled Life: How Fungi Make Our Worlds, Change Our Minds and Shape Our Futures",
+    "url": "https://en.wikipedia.org/wiki/Entangled_Life",
+    "year": 2020
+  },
+  {
+    "author": "Max Chafkin",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "BZ"
+    ],
+    "status": "queued",
+    "title": "The Contrarian",
+    "url": "https://www.penguinrandomhouse.com/books/609711/the-contrarian-by-max-chafkin/",
+    "year": 2021
+  },
+  {
+    "author": "Gary Dorsey",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "STM"
+    ],
+    "status": "queued",
+    "title": "Silicon Sky",
+    "url": "https://www.goodreads.com/book/show/868051.Silicon_Sky",
+    "year": 1999
+  },
+  {
+    "author": "Vernor Vinge",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JMO"
+    ],
+    "status": "queued",
+    "title": "Rainbows End",
+    "url": "https://en.wikipedia.org/wiki/Rainbows_End_(Vinge_novel)",
+    "year": 2006
+  },
+  {
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "Isaac Arthur",
+    "url": "https://en.wikipedia.org/wiki/Isaac_Arthur"
+  },
+  {
+    "author": "Jerry Colonna",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "KY"
+    ],
+    "status": "queued",
+    "title": "Reboot",
+    "url": "https://en.wikipedia.org/wiki/Jerry_Colonna_(financier)",
+    "year": 2019
+  },
+  {
+    "author": "Ronen Bergman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "Rise and Kill First",
+    "url": "https://en.wikipedia.org/wiki/Rise_and_Kill_First",
+    "year": 2018
+  },
+  {
+    "author": "Cormac McCarthy",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "BE",
+      "MF"
+    ],
+    "status": "queued",
+    "title": "The Road",
+    "url": "https://en.wikipedia.org/wiki/The_Road",
+    "year": 2006
+  },
+  {
+    "author": "Marvin Minsky",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "The Society of Mind",
+    "url": "https://en.wikipedia.org/wiki/Society_of_Mind",
+    "year": 1986
+  },
+  {
+    "author": "James S.A. Corey",
+    "category": "series",
+    "checked": true,
+    "recommended_by": [
+      "AC",
+      "ALV",
+      "PL",
+      "UN"
+    ],
+    "status": "queued",
+    "title": "The Expanse",
+    "url": "https://en.wikipedia.org/wiki/The_Expanse_(novel_series)",
+    "year": 2011
+  },
+  {
+    "title": "Seven Pillars of Wisdom",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ALV",
+      "MF"
+    ],
+    "author": "T. E. Lawrence",
+    "year": 1926,
+    "url": "https://en.wikipedia.org/wiki/Seven_Pillars_of_Wisdom",
+    "checked": true
+  },
+  {
+    "title": "Arabian Sands",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "author": "Wilfred Thesiger",
+    "year": 1959,
+    "url": "https://en.wikipedia.org/wiki/Arabian_Sands",
+    "checked": true
+  },
+  {
+    "title": "Libyan Sands",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "author": "Ralph Bagnold",
+    "year": 1935,
+    "url": "https://en.wikipedia.org/wiki/Libyan_Sands",
+    "checked": true
+  },
+  {
+    "title": "On Writing: A Memoir of the Craft",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CD"
+    ],
+    "author": "Stephen King",
+    "year": 2000,
+    "url": "https://en.wikipedia.org/wiki/On_Writing:_A_Memoir_of_the_Craft",
+    "checked": true
+  },
+  {
+    "title": "The Last Temptation of Christ",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "author": "Nikos Kazantzakis",
+    "year": 1955,
+    "url": "https://en.wikipedia.org/wiki/The_Last_Temptation_of_Christ_(novel)",
+    "checked": true
+  },
+  {
+    "title": "There Will Be Blood",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "director": "Paul Thomas Anderson",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/There_Will_Be_Blood",
+    "checked": true
+  },
+  {
+    "title": "Astoria",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "author": "Peter Stark",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Astoria_(book)",
+    "checked": true
+  },
+  {
+    "title": "NORAD ids",
+    "category": "topic",
+    "status": "queued",
+    "url": "https://twitter.com/TSKelso/status/1469392021055946757?t=3lpWdQNjdOiAy3Ashji2hw&s=09",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Broken Earth Trilogy",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "GC"
+    ],
+    "author": "N. K. Jemisin",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/N._K._Jemisin#Broken_Earth_series",
+    "checked": true
+  },
+  {
+    "title": "Norse Mythology",
+    "category": "book",
+    "status": "queued",
+    "author": "Neil Gaiman",
+    "recommended_by": [
+      "GC"
+    ],
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Norse_Mythology_(book)",
+    "checked": true
+  },
+  {
+    "author": "Peter Wang",
+    "category": "podcast",
+    "checked": true,
+    "status": "queued",
+    "title": "#250 – Peter Wang: Python and the Source Code of Humans, Computers, and Reality | Lex Fridman Podcast",
+    "url": "https://lexfridman.com/peter-wang/",
+    "year": 2021,
+    "recommended_by": []
+  },
+  {
+    "category": "article",
+    "checked": true,
+    "status": "queued",
+    "title": "Opinion: We should shift the conversation on space to satellite debris",
+    "url": "https://www.statesman.com/story/opinion/2021/12/20/opinion-we-should-shift-conversation-space-satellite-debris/8911508002/",
+    "year": 2021,
+    "recommended_by": []
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "director": "Robert Kurvitz",
+    "recommended_by": [
+      "EAI",
+      "JWE"
+    ],
+    "status": "queued",
+    "title": "Disco Elysium",
+    "url": "https://en.wikipedia.org/wiki/Disco_Elysium",
+    "year": 2019
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "director": "Daniel Mullins",
+    "recommended_by": [
+      "EAI"
+    ],
+    "status": "queued",
+    "title": "Inscryption",
+    "url": "https://en.wikipedia.org/wiki/Inscryption",
+    "year": 2021
+  },
+  {
+    "author": "Becky Chambers",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "To Be Taught, If Fortunate",
+    "url": "https://en.wikipedia.org/wiki/To_Be_Taught,_If_Fortunate",
+    "year": 2019
+  },
+  {
+    "author": "Hanzi Freinacht",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "The Listening Society",
+    "year": 2017
+  },
+  {
+    "author": "César Hidalgo",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "Why Information Grows",
+    "year": 2015
+  },
+  {
+    "author": "Manuel DeLanda",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "A Thousand Years of Nonlinear History",
+    "year": 1997
+  },
+  {
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "Cultural Evolution"
+  },
+  {
+    "author": "Eric D. Beinhocker",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "The Origin of Wealth",
+    "url": "https://en.wikipedia.org/wiki/The_Origin_of_Wealth",
+    "year": 2006
+  },
+  {
+    "author": "David F. Noble",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "Forces of Production",
+    "url": "https://en.wikipedia.org/wiki/David_F._Noble",
+    "year": 1984
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Jim Jarmusch",
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Only Lovers Left Alive",
+    "url": "https://en.wikipedia.org/wiki/Only_Lovers_Left_Alive",
+    "year": 2013
+  },
+  {
+    "author": "Stephen Diehl",
+    "category": "article",
+    "checked": true,
+    "status": "queued",
+    "title": "On NFTs",
+    "url": "https://twitter.com/smdiehl/status/1484682114889138184?t=jyvhhNg0YfASMV87ZpVzuw&s=09",
+    "year": 2022,
+    "recommended_by": []
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Peter Mortimer, Nick Rosen",
+    "recommended_by": [
+      "JWE",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "The Alpinist",
+    "url": "https://en.wikipedia.org/wiki/The_Alpinist",
+    "year": 2021
+  },
+  {
+    "author": "Greg Egan",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TBR"
+    ],
+    "status": "queued",
+    "title": "Diaspora",
+    "url": "https://en.wikipedia.org/wiki/Diaspora_(novel)",
+    "year": 1997
+  },
+  {
+    "author": "Merlin Sheldrake",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "VK"
+    ],
+    "status": "queued",
+    "title": "Entangled Life",
+    "url": "https://en.wikipedia.org/wiki/Entangled_Life",
+    "year": 2020
+  },
+  {
+    "author": "Charlie Jane Anders",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Never Say You Can't Survive",
+    "url": "https://en.wikipedia.org/wiki/Never_Say_You_Can%27t_Survive",
+    "year": 2021
+  },
+  {
+    "author": "Charlie Jane Anders",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AL",
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "The City in the Middle of the Night",
+    "url": "https://en.wikipedia.org/wiki/The_City_in_the_Middle_of_the_Night",
+    "year": 2019
+  },
+  {
+    "author": "Mindy Nettifee",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "VK"
+    ],
+    "status": "queued",
+    "title": "Glitter in the Blood",
+    "url": "https://www.goodreads.com/book/show/15039205-glitter-in-the-blood",
+    "year": 2012
+  },
+  {
+    "title": "The Center Cannot Hold: My Journey Through Madness",
+    "status": "queued",
+    "recommended_by": [
+      "EE"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Elyn R. Saks",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/The_Center_Cannot_Hold_(book)"
+  },
+  {
+    "title": "Still Alice",
+    "status": "queued",
+    "recommended_by": [
+      "KL"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Lisa Genova",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/Still_Alice_(novel)"
+  },
+  {
+    "title": "Radical Acceptance",
+    "status": "queued",
+    "recommended_by": [
+      "WA"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Tara Brach",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Tara_Brach"
+  },
+  {
+    "title": "Good Omens",
+    "status": "queued",
+    "recommended_by": [
+      "EU",
+      "UN"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Terry Pratchett and Neil Gaiman",
+    "year": 1990,
+    "url": "https://en.wikipedia.org/wiki/Good_Omens"
+  },
+  {
+    "title": "Tenet",
+    "status": "queued",
+    "recommended_by": [
+      "CKE",
+      "EU",
+      "PN"
+    ],
+    "checked": true,
+    "category": "movie",
+    "director": "Christopher Nolan",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Tenet"
+  },
+  {
+    "title": "How to Make Sh*t Happen",
+    "status": "queued",
+    "recommended_by": [
+      "NA"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Sean Whalen",
+    "year": 2018,
+    "url": "https://www.goodreads.com/book/show/38333723"
+  },
+  {
+    "title": "Hold Me Tight",
+    "status": "queued",
+    "author": "Sue Johnson",
+    "recommended_by": [
+      "ANY",
+      "Rando(unknown)",
+      "MMC"
+    ],
+    "checked": true,
+    "category": "book",
+    "year": 2008,
+    "url": "https://www.goodreads.com/book/show/2153780.Hold_Me_Tight"
+  },
+  {
+    "title": "Secretary",
+    "status": "queued",
+    "recommended_by": [
+      "AMC",
+      "PAB"
+    ],
+    "checked": true,
+    "category": "movie",
+    "director": "Steven Shainberg",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/Secretary_(2002_film)"
+  },
+  {
+    "title": "Klara and the Sun",
+    "status": "queued",
+    "recommended_by": [
+      "Rando(unknown)",
+      "MF"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Kazuo Ishiguro",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Klara_and_the_Sun"
+  },
+  {
+    "title": "The Breathing Method",
+    "status": "queued",
+    "recommended_by": [
+      "TG"
+    ],
+    "checked": true,
+    "category": "book",
+    "author": "Stephen King",
+    "year": 1982,
+    "url": "https://en.wikipedia.org/wiki/The_Breathing_Method"
+  },
+  {
+    "title": "Journey to the Edge of Reason: The Life of Kurt Gödel",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TG"
+    ],
+    "notes": "Bio of Kurt Godel",
+    "author": "Stephen Budiansky",
+    "year": 2021,
+    "url": "https://www.goodreads.com/book/show/55298400-journey-to-the-edge-of-reason",
+    "checked": true
+  },
+  {
+    "title": "Polysecure",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GHS"
+    ],
+    "author": "Jessica Fern",
+    "year": 2020,
+    "url": "https://thornapplepress.ca/books/polysecure/",
+    "checked": true
+  },
+  {
+    "title": "Tennyson",
+    "category": "music",
+    "status": "queued",
+    "recommended_by": [
+      "IC"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Tennyson_(band)",
+    "checked": true
+  },
+  {
+    "title": "Red Rising",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AD"
+    ],
+    "author": "Pierce Brown",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Red_Rising",
+    "checked": true
+  },
+  {
+    "title": "Jiro Dreams of Sushi",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "director": "David Gelb",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Jiro_Dreams_of_Sushi",
+    "checked": true
+  },
+  {
+    "title": "The Old Man and the Sea",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "author": "Ernest Hemingway",
+    "year": 1952,
+    "url": "https://en.wikipedia.org/wiki/The_Old_Man_and_the_Sea",
+    "checked": true
+  },
+  {
+    "title": "Inherent Vice",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "PVI"
+    ],
+    "author": "Thomas Pynchon",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Inherent_Vice",
+    "checked": true
+  },
+  {
+    "title": "Normal People",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EA"
+    ],
+    "author": "Sally Rooney",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Normal_People",
+    "checked": true
+  },
+  {
+    "title": "A Memory Called Empire",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LLE"
+    ],
+    "author": "Arkady Martine",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/A_Memory_Called_Empire",
+    "checked": true
+  },
+  {
+    "category": "music",
+    "checked": true,
+    "recommended_by": [
+      "IC"
+    ],
+    "status": "queued",
+    "title": "Carpenter Brut",
+    "url": "https://en.wikipedia.org/wiki/Carpenter_Brut"
+  },
+  {
+    "author": "Charles Stross",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Rule 34",
+    "url": "https://en.wikipedia.org/wiki/Rule_34_(novel)",
+    "year": 2011
+  },
+  {
+    "author": "Ken Wilber",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "PAU"
+    ],
+    "status": "queued",
+    "title": "A Brief History of Everything",
+    "url": "https://en.wikipedia.org/wiki/Ken_Wilber",
+    "year": 1996
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "CB"
+    ],
+    "status": "queued",
+    "title": "Centaur Land"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Frank Oz",
+    "recommended_by": [
+      "RE"
+    ],
+    "status": "queued",
+    "title": "In & Of Itself",
+    "url": "https://en.wikipedia.org/wiki/Derek_DelGaudio",
+    "year": 2021
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "RE"
+    ],
+    "status": "queued",
+    "title": "Counterpart",
+    "url": "https://en.wikipedia.org/wiki/Counterpart_(TV_series)",
+    "year": 2017
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "JCO"
+    ],
+    "status": "queued",
+    "title": "Cyberpunk"
+  },
+  {
+    "author": "Dave Eggers",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EAI"
+    ],
+    "status": "queued",
+    "title": "The Every",
+    "url": "https://en.wikipedia.org/wiki/The_Every",
+    "year": 2021
+  },
+  {
+    "author": "Sebastian Mallaby",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AF"
+    ],
+    "status": "queued",
+    "title": "The Power Law",
+    "url": "https://en.wikipedia.org/wiki/Sebastian_Mallaby",
+    "year": 2022
+  },
+  {
+    "category": "podcast",
+    "checked": true,
+    "status": "queued",
+    "title": "Laura Crabtree Interview",
+    "url": "https://twitter.com/EVONA_Space/status/1526913731162255362?t=y0b-yvDegCP0JAO6pI8tCQ&s=09",
+    "recommended_by": []
+  },
+  {
+    "title": "Empire of Pain",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LBH"
+    ],
+    "author": "Patrick Radden Keefe",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Empire_of_Pain",
+    "checked": true
+  },
+  {
+    "title": "Mistborn",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "LBH"
+    ],
+    "author": "Brandon Sanderson",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Mistborn:_The_Final_Empire",
+    "checked": true
+  },
+  {
+    "title": "Pharmacopeia",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Murderbot Diaries",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "SB"
+    ],
+    "author": "Martha Wells",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/The_Murderbot_Diaries",
+    "checked": true
+  },
+  {
+    "title": "Manifold Garden",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Manifold_Garden",
+    "checked": true
+  },
+  {
+    "title": "Iron John",
+    "category": "book",
+    "status": "done",
+    "author": "Robert Bly",
+    "rating": 4,
+    "recommended_by": [
+      "Rando(unknown)",
+      "WKZ"
+    ],
+    "year": 1990,
+    "url": "https://en.wikipedia.org/wiki/Iron_John:_A_Book_About_Men",
+    "checked": true
+  },
+  {
+    "title": "Thinking, Fast and Slow",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ",
+      "AMC"
+    ],
+    "author": "Daniel Kahneman",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Thinking,_Fast_and_Slow",
+    "checked": true
+  },
+  {
+    "title": "The Psychology of Money",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "author": "Morgan Housel",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Psychology_of_Money",
+    "checked": true
+  },
+  {
+    "title": "Top Gun: Maverick",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "CN",
+      "CD"
+    ],
+    "director": "Joseph Kosinski",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Top_Gun:_Maverick",
+    "checked": true
+  },
+  {
+    "title": "Euphoria",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "CN",
+      "CD"
+    ],
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Euphoria_(American_TV_series)",
+    "checked": true
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "CN",
+      "CD"
+    ],
+    "status": "queued",
+    "title": "The OA",
+    "url": "https://en.wikipedia.org/wiki/The_OA",
+    "year": 2016
+  },
+  {
+    "author": "Weedan?",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "SWF Audiobook",
+    "url": "https://twitter.com/SWFoundation/status/1534903728129593350?t=EX0h0ftjmy4HFXas45bpEQ&s=09",
+    "recommended_by": []
+  },
+  {
+    "checked": true,
+    "status": "queued",
+    "title": "God of Space Rock, The",
+    "url": "https://twitter.com/TWiT/status/1535673213736431625?t=6JysJOKtBk2Qs659vcTkRQ&s=09",
+    "recommended_by": []
+  },
+  {
+    "author": "Mike Birbiglia",
+    "category": "movie",
+    "checked": true,
+    "recommended_by": [
+      "SHZ"
+    ],
+    "status": "queued",
+    "title": "Mike Birbiglia: The New One",
+    "url": "https://en.wikipedia.org/wiki/Mike_Birbiglia",
+    "year": 2019
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Martha Coolidge",
+    "recommended_by": [
+      "SHZ"
+    ],
+    "status": "queued",
+    "title": "Real Genius",
+    "url": "https://en.wikipedia.org/wiki/Real_Genius",
+    "year": 1985
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "MKI",
+      "AF"
+    ],
+    "status": "queued",
+    "title": "Sense8",
+    "url": "https://en.wikipedia.org/wiki/Sense8",
+    "year": 2015
+  },
+  {
+    "author": "Philip Roth",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DF"
+    ],
+    "status": "queued",
+    "title": "American Pastoral",
+    "url": "https://en.wikipedia.org/wiki/American_Pastoral",
+    "year": 1997
+  },
+  {
+    "author": "QT Luong",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "Treasured Lands: A Photographic Odyssey Through America's National Parks",
+    "url": "https://en.wikipedia.org/wiki/QT_Luong",
+    "year": 2016
+  },
+  {
+    "category": "music",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "U. Utah Phillips",
+    "url": "https://en.wikipedia.org/wiki/Utah_Phillips"
+  },
+  {
+    "author": "Vladislav M. Zubok",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "PR"
+    ],
+    "status": "queued",
+    "title": "Collapse: The Fall of the Soviet Union",
+    "url": "https://en.wikipedia.org/wiki/Collapse:_The_Fall_of_the_Soviet_Union",
+    "year": 2021
+  },
+  {
+    "author": "John Michael Greer",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "The Ecotechnic Future: Envisioning a Post-Peak World",
+    "url": "https://en.wikipedia.org/wiki/John_Michael_Greer",
+    "year": 2009,
+    "recommended_by": []
+  },
+  {
+    "author": "Makoto Yukimura",
+    "category": "other",
+    "checked": true,
+    "recommended_by": [
+      "PB"
+    ],
+    "status": "queued",
+    "title": "Planetes",
+    "url": "https://en.wikipedia.org/wiki/Planetes",
+    "year": 1999
+  },
+  {
+    "author": "Antoine de Saint-Exupéry",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "RAC",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "Wind, Sand and Stars",
+    "url": "https://en.wikipedia.org/wiki/Wind,_Sand_and_Stars",
+    "year": 1939
+  },
+  {
+    "author": "Francis Spufford",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "JBR"
+    ],
+    "status": "queued",
+    "title": "Red Plenty",
+    "url": "https://en.wikipedia.org/wiki/Francis_Spufford",
+    "year": 2010
+  },
+  {
+    "author": "Caveat Magister",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AMC"
+    ],
+    "status": "queued",
+    "title": "Turn Your Life Into Art: Lessons in Psychomagic from the San Francisco Underground",
+    "year": 2021
+  },
+  {
+    "author": "Samuel R. Delany",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MEP"
+    ],
+    "status": "queued",
+    "title": "Nova",
+    "url": "https://en.wikipedia.org/wiki/Nova_(novel)",
+    "year": 1968
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "FW",
+      "LLE"
+    ],
+    "status": "queued",
+    "title": "Untitled Goose Game",
+    "url": "https://en.wikipedia.org/wiki/Untitled_Goose_Game",
+    "year": 2019
+  },
+  {
+    "author": "Julio Cortázar",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "FW"
+    ],
+    "status": "queued",
+    "title": "Blow-Up and Other Stories",
+    "url": "https://en.wikipedia.org/wiki/Blow-Up_and_Other_Stories",
+    "year": 1967
+  },
+  {
+    "author": "Alex Ross",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "FW"
+    ],
+    "status": "queued",
+    "title": "The Rest Is Noise: Listening to the Twentieth Century",
+    "url": "https://en.wikipedia.org/wiki/The_Rest_Is_Noise",
+    "year": 2007
+  },
+  {
+    "category": "music",
+    "checked": true,
+    "status": "queued",
+    "title": "Dvořák Symphony No. 9 \"New World\" — Celibidache, Münchner Philharmoniker, 1991",
+    "url": "https://youtu.be/pHyN3izk38c",
+    "year": 1991,
+    "recommended_by": []
+  },
+  {
+    "title": "First Dwarf",
+    "category": "game",
+    "status": "queued",
+    "url": "https://store.steampowered.com/app/1714900/First_Dwarf/",
+    "year": 2024,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Adaptations",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "checked": true
+  },
+  {
+    "title": "There Is No Antimemetics Division",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "EK",
+      "JWE",
+      "MEA"
+    ],
+    "author": "qntm",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/There_Is_No_Antimemetics_Division",
+    "checked": true
+  },
+  {
+    "title": "Automated",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Stardew Valley",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "FW",
+      "MEA"
+    ],
+    "author": "ConcernedApe",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Stardew_Valley",
+    "checked": true
+  },
+  {
+    "title": "Solaris",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "FW",
+      "PBL"
+    ],
+    "director": "Andrei Tarkovsky",
+    "year": 1972,
+    "url": "https://en.wikipedia.org/wiki/Solaris_(1972_film)",
+    "checked": true,
+    "author": "Stanisław Lem"
+  },
+  {
+    "title": "Severance",
+    "category": "series",
+    "status": "done",
+    "recommended_by": [
+      "FW",
+      "HH",
+      "JCO",
+      "MEA"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Severance_(TV_series)",
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "Annihilation",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "FW"
+    ],
+    "author": "Jeff VanderMeer",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Annihilation_(VanderMeer_novel)",
+    "checked": true
+  },
+  {
+    "title": "Paper Girls",
+    "category": "other",
+    "status": "queued",
+    "recommended_by": [
+      "CD"
+    ],
+    "author": "Brian K. Vaughan",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Paper_Girls",
+    "checked": true
+  },
+  {
+    "title": "The Hero's Journey",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MMC"
+    ],
+    "author": "Joseph Campbell",
+    "year": 1990,
+    "url": "https://en.wikipedia.org/wiki/The_Hero%27s_Journey_(book)",
+    "checked": true
+  },
+  {
+    "author": "Robert Caro",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "PM",
+      "HJK"
+    ],
+    "status": "queued",
+    "title": "The Power Broker",
+    "url": "https://en.wikipedia.org/wiki/The_Power_Broker",
+    "year": 1974
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Slime Rancher 2",
+    "url": "https://en.wikipedia.org/wiki/Slime_Rancher_2",
+    "year": 2025
+  },
+  {
+    "author": "James Clavell",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EBF"
+    ],
+    "status": "queued",
+    "title": "Shōgun",
+    "url": "https://en.wikipedia.org/wiki/Sh%C5%8Dgun_(novel)",
+    "year": 1975
+  },
+  {
+    "author": "Alan Lightman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NH"
+    ],
+    "status": "queued",
+    "title": "Einstein's Dreams",
+    "url": "https://en.wikipedia.org/wiki/Einstein%27s_Dreams",
+    "year": 1992
+  },
+  {
+    "author": "Joe Haldeman",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "PGS"
+    ],
+    "status": "queued",
+    "title": "The Forever War",
+    "url": "https://en.wikipedia.org/wiki/The_Forever_War",
+    "year": 1974
+  },
+  {
+    "author": "Christian Janot",
+    "category": "book",
+    "checked": true,
+    "rating": 3,
+    "status": "done",
+    "tags": [
+      "Textbook",
+      "math"
+    ],
+    "title": "Quasicrystals: A Primer",
+    "url": "https://en.wikipedia.org/wiki/Christian_Janot",
+    "year": 1992,
+    "recommended_by": []
+  },
+  {
+    "author": "Philip K. Dick",
+    "category": "book",
+    "checked": true,
+    "rating": 5,
+    "status": "done",
+    "title": "Do Androids Dream of Electric Sheep?",
+    "url": "https://en.wikipedia.org/wiki/Do_Androids_Dream_of_Electric_Sheep%3F",
+    "year": 1968,
+    "recommended_by": []
+  },
+  {
+    "author": "Marjorie Senechal",
+    "category": "book",
+    "checked": true,
+    "rating": 4,
+    "status": "done",
+    "tags": [
+      "Materials",
+      "Textbook",
+      "math"
+    ],
+    "title": "Quasicrystals and Geometry",
+    "url": "https://en.wikipedia.org/wiki/Quasicrystals_and_Geometry",
+    "year": 1995,
+    "recommended_by": []
+  },
+  {
+    "author": "Robert Kegan and Lisa Laskow Lahey",
+    "category": "book",
+    "checked": true,
+    "status": "done",
+    "title": "An Everyone Culture",
+    "url": "https://www.goodreads.com/book/show/25159550-an-everyone-culture",
+    "year": 2016,
+    "recommended_by": [],
+    "rating": 3
+  },
+  {
+    "category": "book",
+    "checked": true,
+    "rating": 3,
+    "status": "done",
+    "title": "Managing Yourself",
+    "recommended_by": []
+  },
+  {
+    "author": "Jim Dethmer, Diana Chapman, Kaley Klemp",
+    "category": "book",
+    "checked": true,
+    "rating": 4,
+    "status": "done",
+    "tags": [
+      "Leadership"
+    ],
+    "title": "The 15 Commitments of Conscious Leadership",
+    "year": 2015,
+    "recommended_by": []
+  },
+  {
+    "category": "podcast",
+    "checked": true,
+    "status": "queued",
+    "title": "Huberman Lab",
+    "url": "https://en.wikipedia.org/wiki/Andrew_Huberman",
+    "year": 2021,
+    "recommended_by": []
+  },
+  {
+    "author": "Buddy Levy",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "BD"
+    ],
+    "status": "queued",
+    "title": "Conquistador",
+    "year": 2008
+  },
+  {
+    "category": "article",
+    "checked": true,
+    "status": "queued",
+    "title": "UVC: Maryanna Saenko from Future Ventures on investing with an abundance mindset, 3 questions she asks while assessing a deep tech startup and future of food and energy | Understanding VC",
+    "url": "https://www.understandingvc.com/uvc-maryanna-saenko-from-future-ventures/",
+    "recommended_by": []
+  },
+  {
+    "author": "Adrian Tchaikovsky",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "BMB",
+      "MP"
+    ],
+    "status": "queued",
+    "title": "Children of Ruin",
+    "url": "https://en.wikipedia.org/wiki/Children_of_Ruin",
+    "year": 2019
+  },
+  {
+    "author": "Andrea Gibson",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "You Better Be Lightning",
+    "url": "https://en.wikipedia.org/wiki/Andrea_Gibson",
+    "year": 2021,
+    "recommended_by": []
+  },
+  {
+    "author": "Katrina van Grouw",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "NS"
+    ],
+    "status": "queued",
+    "title": "Unnatural Selection",
+    "year": 2018
+  },
+  {
+    "author": "Tarsem Singh",
+    "category": "movie",
+    "checked": true,
+    "director": "Tarsem Singh",
+    "recommended_by": [
+      "DO"
+    ],
+    "status": "queued",
+    "title": "The Fall",
+    "url": "https://en.wikipedia.org/wiki/The_Fall_(2006_film)",
+    "year": 2006
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Dean Fleischer Camp",
+    "recommended_by": [
+      "EAI"
+    ],
+    "status": "queued",
+    "title": "Marcel the Shell with Shoes On",
+    "url": "https://en.wikipedia.org/wiki/Marcel_the_Shell_with_Shoes_On_(2021_film)",
+    "year": 2021
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Sally Potter",
+    "recommended_by": [
+      "NP"
+    ],
+    "status": "queued",
+    "title": "The Party",
+    "url": "https://en.wikipedia.org/wiki/The_Party_(2017_film)",
+    "year": 2017
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Bryan Singer",
+    "recommended_by": [
+      "AME"
+    ],
+    "status": "queued",
+    "title": "The Usual Suspects",
+    "url": "https://en.wikipedia.org/wiki/The_Usual_Suspects",
+    "year": 1995
+  },
+  {
+    "author": "John L. Gustafson",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "The End of Error",
+    "year": 2015
+  },
+  {
+    "author": "Neil Gaiman",
+    "category": "series",
+    "checked": true,
+    "recommended_by": [
+      "CD",
+      "NR"
+    ],
+    "status": "queued",
+    "title": "The Sandman",
+    "url": "https://en.wikipedia.org/wiki/The_Sandman_(comic_book)",
+    "year": 1989
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Wes Anderson",
+    "status": "queued",
+    "title": "Moonrise Kingdom",
+    "url": "https://en.wikipedia.org/wiki/Moonrise_Kingdom",
+    "year": 2012,
+    "recommended_by": []
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "JWE",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Portal 2",
+    "url": "https://en.wikipedia.org/wiki/Portal_2",
+    "year": 2011
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "recommended_by": [
+      "SG"
+    ],
+    "status": "queued",
+    "title": "The Man Who Fell to Earth",
+    "url": "https://en.wikipedia.org/wiki/The_Man_Who_Fell_to_Earth_(TV_series)",
+    "year": 2022
+  },
+  {
+    "author": "Douglas Brinkley",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "XY"
+    ],
+    "status": "queued",
+    "title": "American Moonshot",
+    "url": "https://www.goodreads.com/book/show/36501774-american-moonshot",
+    "year": 2019
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Jonathan Demme",
+    "recommended_by": [
+      "CN"
+    ],
+    "status": "queued",
+    "title": "Stop Making Sense",
+    "url": "https://en.wikipedia.org/wiki/Stop_Making_Sense",
+    "year": 1984
+  },
+  {
+    "author": "Kevin Kelly",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "What Technology Wants",
+    "url": "https://en.wikipedia.org/wiki/What_Technology_Wants",
+    "year": 2010
+  },
+  {
+    "author": "Kevin Kelly",
+    "category": "topic",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "The Technium",
+    "url": "https://kk.org/thetechnium/"
+  },
+  {
+    "author": "Brian Christian and Tom Griffiths",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CD"
+    ],
+    "status": "queued",
+    "title": "Algorithms to Live By",
+    "url": "https://en.wikipedia.org/wiki/Algorithms_to_Live_By",
+    "year": 2016
+  },
+  {
+    "category": "series",
+    "checked": true,
+    "director": "Nathan Fielder",
+    "recommended_by": [
+      "EAI",
+      "MKI"
+    ],
+    "status": "queued",
+    "title": "The Rehearsal",
+    "url": "https://en.wikipedia.org/wiki/The_Rehearsal_(TV_series)",
+    "year": 2022
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Judy Irving",
+    "recommended_by": [
+      "RH"
+    ],
+    "status": "queued",
+    "title": "The Wild Parrots of Telegraph Hill",
+    "url": "https://en.wikipedia.org/wiki/The_Wild_Parrots_of_Telegraph_Hill",
+    "year": 2003
+  },
+  {
+    "category": "series",
+    "checked": true,
+    "director": "Mike White",
+    "recommended_by": [
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "The White Lotus",
+    "url": "https://en.wikipedia.org/wiki/The_White_Lotus",
+    "year": 2021
+  },
+  {
+    "category": "series",
+    "checked": true,
+    "director": "Tony Gilroy",
+    "recommended_by": [
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Andor",
+    "url": "https://en.wikipedia.org/wiki/Andor_(TV_series)",
+    "year": 2022
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "VK"
+    ],
+    "status": "queued",
+    "title": "Chicken John's book"
+  },
+  {
+    "author": "Dan Charles",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DEB"
+    ],
+    "status": "queued",
+    "title": "Lords of the Harvest",
+    "url": "https://www.goodreads.com/book/show/349665.Lords_Of_The_Harvest",
+    "year": 2001
+  },
+  {
+    "title": "The Game",
+    "category": "movie",
+    "status": "queued",
+    "director": "David Fincher",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/The_Game_(1997_film)",
+    "recommended_by": [
+      "SK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "David Lang youtube",
+    "category": "music",
+    "status": "queued",
+    "url": "https://en.wikipedia.org/wiki/David_Lang_(composer)",
+    "recommended_by": [
+      "SK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Tunic",
+    "category": "game",
+    "status": "queued",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Tunic_(video_game)",
+    "recommended_by": [
+      "EAI"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Discoverers",
+    "category": "book",
+    "status": "queued",
+    "author": "Daniel J. Boorstin",
+    "year": 1983,
+    "url": "https://en.wikipedia.org/wiki/The_Discoverers",
+    "recommended_by": [
+      "DA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Antarctic Housewife",
+    "category": "book",
+    "status": "queued",
+    "author": "Nan Brown",
+    "year": 1996,
+    "recommended_by": [
+      "KS"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Intention of Nature, The",
+    "status": "queued",
+    "recommended_by": [
+      "KS",
+      "SK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Laws of Human Nature",
+    "category": "book",
+    "status": "queued",
+    "author": "Robert Greene",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Robert_Greene_(American_author)",
+    "recommended_by": [
+      "MMA",
+      "SA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "How the Hippies Saved Physics",
+    "category": "book",
+    "status": "queued",
+    "author": "David Kaiser",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/How_the_Hippies_Saved_Physics",
+    "recommended_by": [
+      "FM"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Cyberchase",
+    "category": "series",
+    "status": "queued",
+    "year": 2002,
+    "url": "https://en.wikipedia.org/wiki/Cyberchase",
+    "notes": "KidsSeries",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Power of Myth",
+    "category": "book",
+    "status": "queued",
+    "author": "Joseph Campbell and Bill Moyers",
+    "year": 1988,
+    "url": "https://en.wikipedia.org/wiki/Joseph_Campbell_and_the_Power_of_Myth",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Silk Roads: A New History of the World",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "author": "Peter Frankopan",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/The_Silk_Roads_(Frankopan_book)",
+    "checked": true
+  },
+  {
+    "title": "Orgasm Inc.",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "KP",
+      "MKI"
+    ],
+    "director": "Liz Canner",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Orgasm_Inc.",
+    "checked": true
+  },
+  {
+    "title": "The Peripheral",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "AF",
+      "MKI"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/The_Peripheral_(TV_series)",
+    "checked": true
+  },
+  {
+    "title": "Passengers",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "TG"
+    ],
+    "director": "Morten Tyldum",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Passengers_(2016_film)",
+    "checked": true
+  },
+  {
+    "title": "Roadside Picnic",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "FW"
+    ],
+    "author": "Arkady and Boris Strugatsky",
+    "year": 1972,
+    "url": "https://en.wikipedia.org/wiki/Roadside_Picnic",
+    "checked": true
+  },
+  {
+    "title": "The Power Worshippers: Inside the Dangerous Rise of Religious Nationalism",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CT"
+    ],
+    "author": "Katherine Stewart",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Power_Worshippers",
+    "checked": true
+  },
+  {
+    "title": "Power",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ",
+      "NR"
+    ],
+    "checked": true
+  },
+  {
+    "title": "16 zimettti",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "JOG"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Aurora",
+    "category": "book",
+    "status": "queued",
+    "author": "Kim Stanley Robinson",
+    "recommended_by": [
+      "JCO"
+    ],
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Aurora_(novel)",
+    "checked": true
+  },
+  {
+    "title": "Goodbye Gordon Gekko",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "RN"
+    ],
+    "author": "Anthony Scaramucci",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Gordon_Gekko",
+    "checked": true
+  },
+  {
+    "title": "Nonzero: The Logic of Human Destiny",
+    "category": "book",
+    "status": "queued",
+    "author": "Robert Wright",
+    "recommended_by": [
+      "RN"
+    ],
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/Nonzero:_The_Logic_of_Human_Destiny",
+    "checked": true
+  },
+  {
+    "title": "Things Fall Apart",
+    "category": "book",
+    "status": "queued",
+    "author": "Chinua Achebe",
+    "recommended_by": [
+      "GM"
+    ],
+    "year": 1958,
+    "url": "https://en.wikipedia.org/wiki/Things_Fall_Apart",
+    "checked": true
+  },
+  {
+    "title": "Lost Illusions",
+    "category": "book",
+    "status": "queued",
+    "author": "Honoré de Balzac",
+    "recommended_by": [
+      "BO"
+    ],
+    "year": 1837,
+    "url": "https://en.wikipedia.org/wiki/Lost_Illusions",
+    "checked": true
+  },
+  {
+    "title": "A Star Is Born",
+    "category": "movie",
+    "status": "queued",
+    "director": "Bradley Cooper",
+    "recommended_by": [
+      "BO"
+    ],
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/A_Star_Is_Born_(2018_film)",
+    "checked": true
+  },
+  {
+    "title": "ToDo List, The",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Warrior, king, lover poet",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Tár",
+    "category": "movie",
+    "status": "queued",
+    "director": "Todd Field",
+    "recommended_by": [
+      "BO"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/T%C3%A1r",
+    "checked": true
+  },
+  {
+    "title": "The Mysterious Stranger",
+    "category": "movie",
+    "status": "queued",
+    "url": "https://en.wikipedia.org/wiki/The_Mysterious_Stranger",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Faster Than the Speed of Light",
+    "category": "book",
+    "status": "queued",
+    "author": "João Magueijo",
+    "recommended_by": [
+      "PBL"
+    ],
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/Jo%C3%A3o_Magueijo",
+    "checked": true
+  },
+  {
+    "title": "The Dawn of Everything: A New History of Humanity",
+    "category": "book",
+    "status": "queued",
+    "author": "David Graeber and David Wengrow",
+    "recommended_by": [
+      "STM"
+    ],
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/The_Dawn_of_Everything",
+    "checked": true
+  },
+  {
+    "author": "Charles C. Mann",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AMC"
+    ],
+    "status": "queued",
+    "title": "1491: New Revelations of the Americas Before Columbus",
+    "url": "https://en.wikipedia.org/wiki/1491:_New_Revelations_of_the_Americas_Before_Columbus",
+    "year": 2005
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "AF",
+      "EAI",
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "The Last of Us",
+    "url": "https://en.wikipedia.org/wiki/The_Last_of_Us_(video_game)",
+    "year": 2013
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "director": "Dana Terrace",
+    "recommended_by": [
+      "DO"
+    ],
+    "status": "queued",
+    "title": "Owl House, The",
+    "url": "https://en.wikipedia.org/wiki/The_Owl_House",
+    "year": 2020
+  },
+  {
+    "author": "Will Wight",
+    "category": "series",
+    "checked": true,
+    "notes": "Series of 10 books",
+    "recommended_by": [
+      "MP"
+    ],
+    "status": "queued",
+    "title": "Cradle, The",
+    "url": "https://www.goodreads.com/series/192821-cradle",
+    "year": 2016
+  },
+  {
+    "author": "Barry J. Hutchison",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MP"
+    ],
+    "status": "queued",
+    "title": "Space Team",
+    "url": "https://barryjhutchison.com/space-team/",
+    "year": 2016
+  },
+  {
+    "author": "Eleanor Catton",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AF"
+    ],
+    "status": "queued",
+    "title": "Rehearsal, The",
+    "url": "https://en.wikipedia.org/wiki/The_Rehearsal_(novel)",
+    "year": 2008
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Ruben Östlund",
+    "recommended_by": [
+      "AF",
+      "BE",
+      "MKI"
+    ],
+    "status": "queued",
+    "title": "Triangle of Sadness",
+    "url": "https://en.wikipedia.org/wiki/Triangle_of_Sadness",
+    "year": 2022
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Ruben Östlund",
+    "recommended_by": [
+      "BE",
+      "MKI"
+    ],
+    "status": "queued",
+    "title": "Square, The",
+    "url": "https://en.wikipedia.org/wiki/The_Square_(2017_film)",
+    "year": 2017
+  },
+  {
+    "author": "Michael Gibson",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DS"
+    ],
+    "status": "queued",
+    "title": "Paper Belt on Fire",
+    "url": "https://www.encounterbooks.com/books/paper-belt-fire/",
+    "year": 2022
+  },
+  {
+    "author": "Angela Duckworth",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DS"
+    ],
+    "status": "queued",
+    "title": "Grit",
+    "url": "https://en.wikipedia.org/wiki/Angela_Duckworth",
+    "year": 2016
+  },
+  {
+    "title": "The Space Between Worlds",
+    "category": "book",
+    "status": "queued",
+    "author": "Micaiah Johnson",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Space_Between_Worlds",
+    "recommended_by": [
+      "KC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Last Unicorn",
+    "category": "book",
+    "status": "queued",
+    "author": "Peter S. Beagle",
+    "year": 1968,
+    "url": "https://en.wikipedia.org/wiki/The_Last_Unicorn",
+    "recommended_by": [
+      "KC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "God of War",
+    "category": "game",
+    "status": "queued",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/God_of_War_(2018_video_game)",
+    "recommended_by": [
+      "PBL"
+    ],
+    "checked": true
+  },
+  {
+    "title": "No Man's Sky",
+    "category": "game",
+    "status": "queued",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/No_Man%27s_Sky",
+    "recommended_by": [
+      "PBL"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Shrinking",
+    "category": "tv",
+    "status": "queued",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Shrinking_(TV_series)",
+    "recommended_by": [
+      "GH"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Light & Magic",
+    "category": "tv",
+    "status": "queued",
+    "director": "Lawrence Kasdan",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Light_%26_Magic_(TV_series)",
+    "recommended_by": [
+      "VK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Solenoid",
+    "category": "book",
+    "status": "queued",
+    "author": "Mircea Cărtărescu",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Solenoid_(novel)",
+    "recommended_by": [
+      "AND",
+      "VK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Pretty Problems",
+    "category": "movie",
+    "status": "queued",
+    "director": "Kestrin Pantera",
+    "year": 2022,
+    "url": "https://www.imdb.com/title/tt15566896/",
+    "recommended_by": [
+      "BC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Born a Crime",
+    "category": "book",
+    "status": "queued",
+    "author": "Trevor Noah",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Born_a_Crime",
+    "recommended_by": [
+      "MER"
+    ],
+    "checked": true
+  },
+  {
+    "author": "Bruce J. Hunt",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "TW"
+    ],
+    "status": "queued",
+    "title": "Imperial Science: Cable Telegraphy and Electrical Physics in the Victorian British Empire",
+    "url": "https://www.cambridge.org/core/books/imperial-science/240501C1FB989EAEA3DC66C2B3E59F55",
+    "year": 2021
+  },
+  {
+    "author": "Dov Alfon",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MGI"
+    ],
+    "status": "queued",
+    "title": "A Long Night in Paris",
+    "url": "https://www.goodreads.com/book/show/42295750-a-long-night-in-paris",
+    "year": 2016
+  },
+  {
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "DO"
+    ],
+    "status": "queued",
+    "title": "Slay the Spire",
+    "url": "https://en.wikipedia.org/wiki/Slay_the_Spire",
+    "year": 2019
+  },
+  {
+    "author": "Frank Lantz",
+    "category": "game",
+    "checked": true,
+    "recommended_by": [
+      "DO"
+    ],
+    "status": "queued",
+    "title": "Universal Paperclips",
+    "url": "https://en.wikipedia.org/wiki/Universal_Paperclips",
+    "year": 2017
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Phil Tippett",
+    "recommended_by": [
+      "VK"
+    ],
+    "status": "queued",
+    "title": "Mad God",
+    "url": "https://en.wikipedia.org/wiki/Mad_God",
+    "year": 2021
+  },
+  {
+    "author": "Nick Zentner",
+    "category": "series",
+    "checked": true,
+    "notes": "Youtube",
+    "recommended_by": [
+      "ALV"
+    ],
+    "status": "queued",
+    "title": "Geology Lectures",
+    "url": "https://en.wikipedia.org/wiki/Nick_Zentner"
+  },
+  {
+    "author": "Tom Shepard",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "ALV"
+    ],
+    "status": "queued",
+    "title": "Deasert Books (category)"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "John Madden",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "status": "queued",
+    "title": "Shakespeare in Love",
+    "url": "https://en.wikipedia.org/wiki/Shakespeare_in_Love",
+    "year": 1998
+  },
+  {
+    "author": "Michael Dell",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MGR"
+    ],
+    "status": "queued",
+    "title": "Play Nice But Win",
+    "year": 2021
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Kathryn Bigelow",
+    "recommended_by": [
+      "MGR"
+    ],
+    "status": "queued",
+    "title": "Point Break",
+    "url": "https://en.wikipedia.org/wiki/Point_Break",
+    "year": 1991
+  },
+  {
+    "title": "American Prometheus: The Triumph and Tragedy of J. Robert Oppenheimer",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MMC"
+    ],
+    "author": "Kai Bird and Martin J. Sherwin",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/American_Prometheus",
+    "checked": true
+  },
+  {
+    "title": "A Short History of Nearly Everything",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DPA"
+    ],
+    "author": "Bill Bryson",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/A_Short_History_of_Nearly_Everything",
+    "checked": true
+  },
+  {
+    "title": "The Knife of Never Letting Go",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "KT"
+    ],
+    "author": "Patrick Ness",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/The_Knife_of_Never_Letting_Go",
+    "checked": true
+  },
+  {
+    "title": "The Evolving Self",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JV",
+      "VV"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Bell Labs Memoirs: Voices of Innovation",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "PB"
+    ],
+    "author": "A. Michael Noll and Michael Geselowitz",
+    "year": 2011,
+    "checked": true
+  },
+  {
+    "title": "Upanishads",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CA"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Upanishads",
+    "checked": true
+  },
+  {
+    "title": "Glass House: The 1% Economy and the Shattering of the All-American Town",
+    "category": "book",
+    "status": "queued",
+    "author": "Brian Alexander",
+    "year": 2017,
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "A Court of Thorns and Roses",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DA"
+    ],
+    "author": "Sarah J. Maas",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/A_Court_of_Thorns_and_Roses",
+    "checked": true
+  },
+  {
+    "title": "Legends & Lattes",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LBH"
+    ],
+    "author": "Travis Baldree",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Legends_%26_Lattes",
+    "checked": true
+  },
+  {
+    "title": "Tomorrow, and Tomorrow, and Tomorrow",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LBH"
+    ],
+    "author": "Gabrielle Zevin",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Tomorrow,_and_Tomorrow,_and_Tomorrow_(novel)",
+    "checked": true
+  },
+  {
+    "author": "Daniel J. Siegel and Mary Hartzell",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "PAU"
+    ],
+    "status": "queued",
+    "title": "Parenting from the Inside Out",
+    "url": "https://en.wikipedia.org/wiki/Parenting_from_the_Inside_Out",
+    "year": 2003
+  },
+  {
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LBH"
+    ],
+    "status": "done",
+    "title": "The Swimming Pool",
+    "rating": 3
+  },
+  {
+    "author": "Madeline Miller",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "ANY",
+      "KM",
+      "MP"
+    ],
+    "status": "done",
+    "title": "Circe",
+    "url": "https://en.wikipedia.org/wiki/Circe_(novel)",
+    "year": 2018,
+    "rating": 5
+  },
+  {
+    "author": "Harville Hendrix",
+    "category": "book",
+    "checked": true,
+    "status": "queued",
+    "title": "Getting the Love You Want",
+    "url": "https://en.wikipedia.org/wiki/Getting_the_Love_You_Want",
+    "year": 1988,
+    "recommended_by": []
+  },
+  {
+    "author": "Madeline Miller",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "KM"
+    ],
+    "status": "queued",
+    "title": "The Song of Achilles",
+    "url": "https://en.wikipedia.org/wiki/The_Song_of_Achilles",
+    "year": 2011
+  },
+  {
+    "author": "Shelby Van Pelt",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "ABD"
+    ],
+    "status": "queued",
+    "title": "Remarkably Bright Creatures",
+    "url": "https://en.wikipedia.org/wiki/Remarkably_Bright_Creatures_(novel)",
+    "year": 2022
+  },
+  {
+    "author": "Leigh Bardugo",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "Ninth House",
+    "url": "https://en.wikipedia.org/wiki/Ninth_House",
+    "year": 2019
+  },
+  {
+    "author": "Leigh Bardugo",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "CT"
+    ],
+    "status": "queued",
+    "title": "Hell Bent",
+    "url": "https://en.wikipedia.org/wiki/Ninth_House",
+    "year": 2023
+  },
+  {
+    "author": "David Hackett Fischer",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "GTC"
+    ],
+    "status": "queued",
+    "title": "Albion's Seed",
+    "url": "https://en.wikipedia.org/wiki/Albion%27s_Seed",
+    "year": 1989
+  },
+  {
+    "title": "The Sovereign Individual",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW",
+      "NR"
+    ],
+    "author": "James Dale Davidson and William Rees-Mogg",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/The_Sovereign_Individual",
+    "checked": true
+  },
+  {
+    "title": "The Art of Clear Thinking",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Hasard Lee",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Hasard_Lee",
+    "checked": true
+  },
+  {
+    "title": "Gut",
+    "category": "book",
+    "status": "queued",
+    "author": "Giulia Enders",
+    "recommended_by": [
+      "TS"
+    ],
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Giulia_Enders",
+    "checked": true
+  },
+  {
+    "title": "Eccentric Orbits",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ANJ"
+    ],
+    "author": "John Bloom",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/John_Irving_Bloom",
+    "checked": true
+  },
+  {
+    "title": "Original Sin: Power, Technology and War in Outer Space",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Bleddyn E. Bowen",
+    "year": 2022,
+    "url": "https://academic.oup.com/book/46146",
+    "checked": true
+  },
+  {
+    "title": "The Iron Heel",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SK"
+    ],
+    "author": "Jack London",
+    "year": 1908,
+    "url": "https://en.wikipedia.org/wiki/The_Iron_Heel",
+    "checked": true
+  },
+  {
+    "title": "The Accidental Superpower",
+    "category": "book",
+    "status": "queued",
+    "author": "Peter Zeihan",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Peter_Zeihan",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "The Dawn of Everything",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JWE",
+      "KS",
+      "SK"
+    ],
+    "author": "David Graeber and David Wengrow",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/The_Dawn_of_Everything",
+    "checked": true
+  },
+  {
+    "title": "The Blue Zones",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "BEN"
+    ],
+    "author": "Dan Buettner",
+    "year": 2008,
+    "url": "https://en.wikipedia.org/wiki/Dan_Buettner",
+    "checked": true
+  },
+  {
+    "title": "MerPeople",
+    "category": "tv",
+    "status": "queued",
+    "recommended_by": [
+      "LD"
+    ],
+    "director": "Cynthia Wade",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/MerPeople",
+    "checked": true
+  },
+  {
+    "title": "Scavengers Reign",
+    "category": "series",
+    "status": "queued",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Scavengers_Reign",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "G-Man: J. Edgar Hoover and the Making of the American Century",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MW"
+    ],
+    "author": "Beverly Gage",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/G-Man:_J._Edgar_Hoover_and_the_Making_of_the_American_Century",
+    "checked": true
+  },
+  {
+    "title": "The Fall of the House of Usher",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JB"
+    ],
+    "author": "Edgar Allan Poe",
+    "year": 1839,
+    "url": "https://en.wikipedia.org/wiki/The_Fall_of_the_House_of_Usher",
+    "checked": true
+  },
+  {
+    "title": "Quantum Earth Series",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CJ"
+    ],
+    "author": "Dennis E. Taylor",
+    "year": 2019,
+    "url": "https://www.goodreads.com/series/359398-quantum-earth",
+    "checked": true
+  },
+  {
+    "title": "Neon Gods Series",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LLE"
+    ],
+    "author": "Katee Robert",
+    "year": 2022,
+    "url": "https://www.goodreads.com/series/298532-dark-olympus",
+    "checked": true
+  },
+  {
+    "title": "Innkeeper Chronicles",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LLE"
+    ],
+    "author": "Ilona Andrews",
+    "year": 2013,
+    "url": "https://www.goodreads.com/series/117790-innkeeper-chronicles",
+    "checked": true
+  },
+  {
+    "title": "The Road to Serfdom",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "F. A. Hayek",
+    "year": 1944,
+    "url": "https://en.wikipedia.org/wiki/The_Road_to_Serfdom",
+    "checked": true
+  },
+  {
+    "title": "Breath: The New Science of a Lost Art",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ML"
+    ],
+    "author": "James Nestor",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Breath:_The_New_Science_of_a_Lost_Art",
+    "checked": true
+  },
+  {
+    "title": "The Pigeon Tunnel: Stories from My Life",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GEG"
+    ],
+    "author": "John le Carré",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/The_Pigeon_Tunnel:_Stories_from_My_Life",
+    "checked": true
+  },
+  {
+    "title": "Blue Eye Samurai",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Blue_Eye_Samurai",
+    "checked": true
+  },
+  {
+    "title": "Parenting from the Inside Out: How a Deeper Self-Understanding Can Help You Raise Children Who Thrive",
+    "category": "book",
+    "status": "queued",
+    "author": "Daniel J. Siegel and Mary Hartzell",
+    "year": 2003,
+    "url": "https://www.amazon.com/Parenting-Inside-Out-Self-Understanding-Anniversary/dp/039916510X",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "No-Drama Discipline: The Whole-Brain Way to Calm the Chaos and Nurture Your Child's Developing Mind",
+    "category": "book",
+    "status": "queued",
+    "author": "Daniel J. Siegel and Tina Payne Bryson",
+    "year": 2014,
+    "url": "https://www.penguinrandomhouse.com/books/228322/no-drama-discipline-by-daniel-j-siegel-md-and-tina-payne-bryson-phd/",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Starfield",
+    "category": "game",
+    "status": "queued",
+    "director": "Todd Howard",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Starfield_(video_game)",
+    "recommended_by": [
+      "TW"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Death Stranding",
+    "category": "game",
+    "status": "queued",
+    "director": "Hideo Kojima",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Death_Stranding",
+    "recommended_by": [
+      "GTC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Upon the Mirror Sea",
+    "category": "other",
+    "status": "done",
+    "url": "https://mirrorsea.xyz/",
+    "recommended_by": [
+      "CP"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "title": "The Way of Kings",
+    "category": "book",
+    "status": "done",
+    "author": "Brandon Sanderson",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/The_Way_of_Kings",
+    "recommended_by": [
+      "KB"
+    ],
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "True Names",
+    "category": "book",
+    "status": "queued",
+    "author": "Vernor Vinge",
+    "year": 1981,
+    "url": "https://en.wikipedia.org/wiki/True_Names",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "What We Do in the Shadows",
+    "category": "movie",
+    "status": "queued",
+    "director": "Jemaine Clement and Taika Waititi",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/What_We_Do_in_the_Shadows",
+    "recommended_by": [
+      "JPE",
+      "MEA",
+      "NK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Flight of the Conchords",
+    "category": "tv",
+    "status": "queued",
+    "year": 2007,
+    "url": "https://en.wikipedia.org/wiki/Flight_of_the_Conchords_(TV_series)",
+    "recommended_by": [
+      "JPE",
+      "NK"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Discworld",
+    "category": "series",
+    "status": "done",
+    "author": "Terry Pratchett",
+    "year": 1983,
+    "url": "https://en.wikipedia.org/wiki/Discworld",
+    "recommended_by": [
+      "GTC"
+    ],
+    "checked": true,
+    "rating": 3
+  },
+  {
+    "author": "Barbara Kingsolver",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "WKZ"
+    ],
+    "status": "queued",
+    "title": "Demon Copperhead",
+    "url": "https://en.wikipedia.org/wiki/Demon_Copperhead",
+    "year": 2022
+  },
+  {
+    "author": "Tara Westover",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "WKZ"
+    ],
+    "status": "queued",
+    "title": "Educated: A Memoir",
+    "url": "https://en.wikipedia.org/wiki/Educated_(memoir)",
+    "year": 2018
+  },
+  {
+    "author": "Robert Sapolsky",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MMC"
+    ],
+    "status": "queued",
+    "title": "A Primate's Memoir",
+    "url": "https://en.wikipedia.org/wiki/A_Primate%27s_Memoir",
+    "year": 2001
+  },
+  {
+    "author": "Robert Sapolsky",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MMC"
+    ],
+    "status": "queued",
+    "title": "Determined: A Science of Life Without Free Will",
+    "url": "https://en.wikipedia.org/wiki/Determined:_A_Science_of_Life_Without_Free_Will",
+    "year": 2023
+  },
+  {
+    "checked": true,
+    "recommended_by": [
+      "CO"
+    ],
+    "status": "queued",
+    "title": "Storm, the"
+  },
+  {
+    "author": "Jennifer Senior",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "GE"
+    ],
+    "status": "queued",
+    "title": "All Joy and No Fun",
+    "url": "https://en.wikipedia.org/wiki/Jennifer_Senior",
+    "year": 2014
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "status": "queued",
+    "title": "The Garden: Commune or Cult",
+    "url": "https://www.imdb.com/title/tt29890377/",
+    "year": 2023,
+    "recommended_by": []
+  },
+  {
+    "author": "Dominika Best",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "Rando(Kate's drunk friend)"
+    ],
+    "status": "queued",
+    "title": "Ghosts of Los Angeles"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Sam Esmail",
+    "recommended_by": [
+      "MKI"
+    ],
+    "status": "queued",
+    "title": "Leave the World Behind",
+    "url": "https://en.wikipedia.org/wiki/Leave_the_World_Behind_(film)",
+    "year": 2023
+  },
+  {
+    "author": "Leo Szilard",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EK"
+    ],
+    "status": "queued",
+    "title": "The Voice of the Dolphins and Other Stories",
+    "url": "https://archive.org/details/voiceofdolphinso00szil_0",
+    "year": 1961
+  },
+  {
+    "title": "The Stormlight Archive",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "GC"
+    ],
+    "author": "Brandon Sanderson",
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/The_Stormlight_Archive",
+    "checked": true
+  },
+  {
+    "title": "Wool",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Hugh Howey",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Silo_(series)",
+    "checked": true
+  },
+  {
+    "title": "Masculinity Amidst Madness",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JMA"
+    ],
+    "author": "Ryan Landry",
+    "year": 2020,
+    "checked": true
+  },
+  {
+    "title": "Possee Rilla",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JMA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Dark Enlightenment",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JMA"
+    ],
+    "author": "Nick Land",
+    "year": 2013,
+    "url": "https://en.wikipedia.org/wiki/Dark_Enlightenment",
+    "checked": true
+  },
+  {
+    "title": "Way of the Superior Man, The",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JMA"
+    ],
+    "checked": true,
+    "author": "David Deida",
+    "year": 1997,
+    "url": "https://en.wikipedia.org/wiki/David_Deida"
+  },
+  {
+    "title": "The Machiavellians",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JMA",
+      "WQ"
+    ],
+    "author": "James Burnham",
+    "year": 1943,
+    "url": "https://en.wikipedia.org/wiki/The_Machiavellians",
+    "checked": true
+  },
+  {
+    "title": "What's Our Problem?",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Tim Urban",
+    "year": 2023,
+    "checked": true
+  },
+  {
+    "title": "An Immense World",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MMC"
+    ],
+    "author": "Ed Yong",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/An_Immense_World",
+    "checked": true
+  },
+  {
+    "title": "Homesteading the Noosphere",
+    "category": "article",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Eric S. Raymond",
+    "year": 1999,
+    "url": "https://en.wikipedia.org/wiki/Homesteading_the_Noosphere",
+    "checked": true
+  },
+  {
+    "title": "Chernobyl",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "MF"
+    ],
+    "director": "Johan Renck",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Chernobyl_(miniseries)",
+    "checked": true
+  },
+  {
+    "title": "The Baroque Cycle",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "PL"
+    ],
+    "author": "Neal Stephenson",
+    "year": 2003,
+    "url": "https://en.wikipedia.org/wiki/The_Baroque_Cycle",
+    "checked": true
+  },
+  {
+    "title": "American Fiction",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "GHS"
+    ],
+    "director": "Cord Jefferson",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/American_Fiction_(film)",
+    "checked": true
+  },
+  {
+    "title": "The Captain Class",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CHH"
+    ],
+    "author": "Sam Walker",
+    "year": 2017,
+    "url": "https://www.penguinrandomhouse.com/books/243390/the-captain-class-by-sam-walker/",
+    "checked": true
+  },
+  {
+    "title": "Leadership and Self-Deception",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CHH"
+    ],
+    "author": "The Arbinger Institute",
+    "year": 2000,
+    "url": "https://arbinger.com/bookstore/leadership-and-self-deception",
+    "checked": true
+  },
+  {
+    "title": "The Outward Mindset",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CHH"
+    ],
+    "author": "The Arbinger Institute",
+    "year": 2016,
+    "url": "https://arbinger.com/bookstore/the-outward-mindset",
+    "checked": true
+  },
+  {
+    "title": "Do Hard Things",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CHH"
+    ],
+    "author": "Steve Magness",
+    "year": 2022,
+    "url": "https://www.stevemagness.com/do-hard-things/",
+    "checked": true
+  },
+  {
+    "title": "On Sparta",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CHH"
+    ],
+    "author": "Plutarch",
+    "url": "https://en.wikipedia.org/wiki/Plutarch",
+    "checked": true
+  },
+  {
+    "title": "Bhagavad Gita",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CA",
+      "MMC",
+      "NR"
+    ],
+    "author": "Vyasa",
+    "url": "https://en.wikipedia.org/wiki/Bhagavad_Gita",
+    "checked": true
+  },
+  {
+    "title": "The Histories",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AMC",
+      "AF",
+      "ALV",
+      "MF"
+    ],
+    "notes": "Ask Anselem for which translation",
+    "author": "Herodotus",
+    "url": "https://en.wikipedia.org/wiki/Histories_(Herodotus)",
+    "checked": true
+  },
+  {
+    "title": "Active Measures: The Secret History of Disinformation and Political Warfare",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Thomas Rid",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Active_Measures_(book)",
+    "checked": true
+  },
+  {
+    "title": "Sextant: A Voyage Guided by the Stars and the Men Who Mapped the World's Oceans",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "RAD"
+    ],
+    "author": "David Barrie",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/David_Ogilvy_Barrie",
+    "checked": true
+  },
+  {
+    "title": "The 360 Degree Leader: Developing Your Influence from Anywhere in the Organization",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ST"
+    ],
+    "author": "John C. Maxwell",
+    "year": 2005,
+    "url": "https://www.goodreads.com/book/show/183396.The_360_Degree_Leader",
+    "checked": true
+  },
+  {
+    "title": "The Speed of Trust: The One Thing That Changes Everything",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ST"
+    ],
+    "author": "Stephen M. R. Covey",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/The_Speed_of_Trust",
+    "checked": true
+  },
+  {
+    "title": "WorkLife with Adam Grant",
+    "category": "podcast",
+    "status": "queued",
+    "author": "Adam Grant",
+    "recommended_by": [
+      "ST"
+    ],
+    "year": 2018,
+    "url": "https://www.ted.com/podcasts/worklife",
+    "checked": true
+  },
+  {
+    "title": "The Official CIA Manual of Trickery and Deception",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MSA"
+    ],
+    "author": "H. Keith Melton and Robert Wallace",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/The_Official_CIA_Manual_of_Trickery_and_Deception",
+    "checked": true
+  },
+  {
+    "title": "A City on Mars: Can We Settle Space, Should We Settle Space, and Have We Really Thought This Through?",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SJ"
+    ],
+    "author": "Kelly Weinersmith and Zach Weinersmith",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/A_City_on_Mars",
+    "checked": true
+  },
+  {
+    "title": "In 'An Immense World', Ed Yong dives deep into animal senses : NPR",
+    "category": "article",
+    "status": "queued",
+    "url": "https://www.npr.org/2022/06/21/1105793891/ed-yong-an-immense-world-animal-senses",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "A Mathematician's Lament",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Paul Lockhart",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/A_Mathematician%27s_Lament",
+    "checked": true
+  },
+  {
+    "title": "The Kill Chain: Defending America in the Future of High-Tech Warfare",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AA"
+    ],
+    "author": "Christian Brose",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/The_Kill_Chain",
+    "checked": true
+  },
+  {
+    "title": "Mindfulness in Plain English",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WKZ"
+    ],
+    "author": "Bhante Henepola Gunaratana",
+    "year": 1994,
+    "url": "https://en.wikipedia.org/wiki/Mindfulness_in_Plain_English",
+    "checked": true
+  },
+  {
+    "title": "The Ancient City",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "WQ"
+    ],
+    "author": "Numa Denis Fustel de Coulanges",
+    "year": 1864,
+    "url": "https://en.wikipedia.org/wiki/The_Ancient_City",
+    "checked": true
+  },
+  {
+    "title": "The Chrysanthemum and the Sword",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "author": "Ruth Benedict",
+    "year": 1946,
+    "url": "https://en.wikipedia.org/wiki/The_Chrysanthemum_and_the_Sword",
+    "checked": true
+  },
+  {
+    "title": "Ringworld",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "DBL"
+    ],
+    "author": "Larry Niven",
+    "year": 1970,
+    "url": "https://en.wikipedia.org/wiki/Ringworld",
+    "checked": true
+  },
+  {
+    "title": "Active Inference: The Free Energy Principle in Mind, Brain, and Behavior",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ES"
+    ],
+    "url": "https://direct.mit.edu/books/oa-monograph/5299/Active-InferenceThe-Free-Energy-Principle-in-Mind",
+    "author": "Thomas Parr, Giovanni Pezzulo, Karl J. Friston",
+    "year": 2022,
+    "checked": true
+  },
+  {
+    "title": "Freedoms Forge",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MIA"
+    ],
+    "checked": true,
+    "author": "Arthur Herman",
+    "year": 2012,
+    "url": "https://en.wikipedia.org/wiki/Freedom%27s_Forge"
+  },
+  {
+    "title": "Inventing Accuracy: A Historical Sociology of Nuclear Missile Guidance",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HV"
+    ],
+    "url": "https://mitpress.mit.edu/9780262631471/inventing-accuracy/",
+    "author": "Donald MacKenzie",
+    "year": 1990,
+    "checked": true
+  },
+  {
+    "title": "The Eye of War: Military Perception from the Telescope to the Drone",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "HV"
+    ],
+    "url": "https://www.upress.umn.edu/book-division/books/the-eye-of-war",
+    "author": "Antoine Bousquet",
+    "year": 2018,
+    "checked": true
+  },
+  {
+    "title": "Lost in Math: How Beauty Leads Physics Astray",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Sabine Hossenfelder",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/Sabine_Hossenfelder",
+    "checked": true
+  },
+  {
+    "title": "Superabundance: The Story of Population Growth, Innovation, and Human Flourishing on an Infinitely Bountiful Planet",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AM"
+    ],
+    "author": "Marian L. Tupy, Gale L. Pooley",
+    "year": 2022,
+    "url": "https://www.superabundance.com/",
+    "checked": true
+  },
+  {
+    "title": "The Computer's Voice: From Star Trek to Siri",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LF"
+    ],
+    "author": "Liz W. Faber",
+    "year": 2020,
+    "url": "https://www.upress.umn.edu/9781517909765/the-computers-voice/",
+    "checked": true
+  },
+  {
+    "title": "The Sun Eater",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "author": "Christopher Ruocchio",
+    "year": 2018,
+    "url": "https://en.wikipedia.org/wiki/The_Sun_Eater",
+    "checked": true
+  },
+  {
+    "title": "Elysium",
+    "category": "book",
+    "status": "queued",
+    "author": "Jennifer Marie Brissett",
+    "year": 2014,
+    "url": "https://www.goodreads.com/book/show/23374690-elysium",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "I, Mammal",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "NE"
+    ],
+    "author": "Liam Drew",
+    "year": 2017,
+    "url": "https://www.goodreads.com/book/show/30038815-i-mammal",
+    "checked": true
+  },
+  {
+    "title": "How the World Really Works",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ALV"
+    ],
+    "notes": "(Re decarbonization)",
+    "author": "Vaclav Smil",
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/How_the_World_Really_Works",
+    "checked": true
+  },
+  {
+    "title": "The Pentagon Wars",
+    "category": "book",
+    "status": "queued",
+    "author": "James G. Burton",
+    "year": 1993,
+    "url": "https://www.goodreads.com/book/show/894123.The_Pentagon_Wars",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Conversations with God",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "TW"
+    ],
+    "author": "Neale Donald Walsch",
+    "year": 1995,
+    "url": "https://en.wikipedia.org/wiki/Conversations_with_God",
+    "checked": true
+  },
+  {
+    "title": "Challengers",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "director": "Luca Guadagnino",
+    "year": 2024,
+    "url": "https://en.wikipedia.org/wiki/Challengers_(film)",
+    "checked": true
+  },
+  {
+    "title": "Atlas of the Heart",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ST"
+    ],
+    "author": "Brene Brown",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Atlas_of_the_Heart",
+    "checked": true
+  },
+  {
+    "title": "Braving the Wilderness",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ST"
+    ],
+    "author": "Brene Brown",
+    "year": 2017,
+    "url": "https://www.goodreads.com/book/show/34565022-braving-the-wilderness",
+    "checked": true
+  },
+  {
+    "title": "This Is How You Lose the Time War",
+    "category": "book",
+    "status": "done",
+    "recommended_by": [
+      "MEA",
+      "NH"
+    ],
+    "author": "Amal El-Mohtar and Max Gladstone",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/This_Is_How_You_Lose_the_Time_War",
+    "checked": true,
+    "rating": 5
+  },
+  {
+    "title": "Terra Invicta",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Terra_Invicta",
+    "checked": true
+  },
+  {
+    "title": "Children of a Dead Earth",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "GTC"
+    ],
+    "year": 2016,
+    "url": "https://store.steampowered.com/app/476530/Children_of_a_Dead_Earth/",
+    "checked": true
+  },
+  {
+    "title": "Free Trade Doesn't Work",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MAH"
+    ],
+    "author": "Ian Fletcher",
+    "year": 2010,
+    "url": "https://www.freetradedoesntwork.com/",
+    "checked": true
+  },
+  {
+    "title": "Margin Call",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "AF",
+      "GTC"
+    ],
+    "director": "J. C. Chandor",
+    "year": 2011,
+    "url": "https://en.wikipedia.org/wiki/Margin_Call",
+    "checked": true
+  },
+  {
+    "title": "Chants of Sennaar",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Chants_of_Sennaar",
+    "checked": true
+  },
+  {
+    "title": "Abstract: The Art of Design",
+    "category": "series",
+    "status": "queued",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Abstract_%E2%80%93_The_Art_of_Design",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Me and You and Everyone We Know",
+    "category": "movie",
+    "status": "queued",
+    "director": "Miranda July",
+    "year": 2005,
+    "url": "https://en.wikipedia.org/wiki/Me_and_You_and_Everyone_We_Know",
+    "checked": true,
+    "recommended_by": []
+  },
+  {
+    "title": "Reputation and Power",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "BS"
+    ],
+    "author": "Daniel Carpenter",
+    "year": 2010,
+    "url": "https://press.princeton.edu/books/paperback/9780691141800/reputation-and-power",
+    "checked": true
+  },
+  {
+    "title": "Our Mathematical Universe",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "rating": 3,
+    "author": "Max Tegmark",
+    "year": 2014,
+    "url": "https://en.wikipedia.org/wiki/Our_Mathematical_Universe",
+    "checked": true
+  },
+  {
+    "title": "Saturn Run",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MGR"
+    ],
+    "author": "John Sandford and Ctein",
+    "year": 2015,
+    "url": "https://en.wikipedia.org/wiki/Saturn_Run",
+    "checked": true
+  },
+  {
+    "title": "Too Like the Lightning",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "MEA"
+    ],
+    "author": "Ada Palmer",
+    "year": 2016,
+    "url": "https://en.wikipedia.org/wiki/Too_Like_the_Lightning",
+    "checked": true
+  },
+  {
+    "title": "Muster Dogs",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "JWE",
+      "MEA"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Muster_Dogs",
+    "checked": true
+  },
+  {
+    "title": "Dyson Sphere Program",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Dyson_Sphere_Program",
+    "checked": true
+  },
+  {
+    "title": "Cocoon",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "GMD"
+    ],
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Cocoon_(video_game)",
+    "checked": true
+  },
+  {
+    "title": "Pantheon",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "JOM",
+      "RH"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Pantheon_(TV_series)",
+    "checked": true
+  },
+  {
+    "title": "Slow Horses",
+    "category": "series",
+    "status": "in-progress",
+    "recommended_by": [
+      "DFR",
+      "JWE",
+      "MEA",
+      "RH"
+    ],
+    "year": 2022,
+    "url": "https://en.wikipedia.org/wiki/Slow_Horses",
+    "checked": true
+  },
+  {
+    "title": "Luther",
+    "category": "series",
+    "status": "queued",
+    "recommended_by": [
+      "ALV",
+      "NES"
+    ],
+    "year": 2010,
+    "url": "https://en.wikipedia.org/wiki/Luther_(TV_series)",
+    "checked": true
+  },
+  {
+    "title": "All Systems Red",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "LG"
+    ],
+    "author": "Martha Wells",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/All_Systems_Red",
+    "checked": true
+  },
+  {
+    "title": "Some Desperate Glory",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "SK"
+    ],
+    "author": "Emily Tesh",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/Some_Desperate_Glory_(novel)",
+    "checked": true
+  },
+  {
+    "title": "Visual Differential Geometry and Forms",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "ASL"
+    ],
+    "url": "https://en.wikipedia.org/wiki/Tristan_Needham",
+    "checked": true,
+    "author": "Tristan Needham",
+    "year": 2021
+  },
+  {
+    "title": "Shop Class as Soulcraft",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JT"
+    ],
+    "checked": true,
+    "author": "Matthew B. Crawford",
+    "year": 2009,
+    "url": "https://en.wikipedia.org/wiki/Matthew_Crawford"
+  },
+  {
+    "title": "Nineteen Ways of Looking at Consciousness",
+    "category": "book",
+    "status": "queued",
+    "url": "https://en.wikipedia.org/wiki/Nineteen_Ways_of_Looking_at_Consciousness",
+    "checked": true,
+    "author": "Patrick House",
+    "year": 2022,
+    "recommended_by": []
+  },
+  {
+    "title": "Enshrouded",
+    "category": "game",
+    "status": "queued",
+    "recommended_by": [
+      "MP"
+    ],
+    "checked": true,
+    "year": 2024,
+    "url": "https://en.wikipedia.org/wiki/Enshrouded"
+  },
+  {
+    "title": "The Producers",
+    "category": "movie",
+    "status": "queued",
+    "recommended_by": [
+      "RH"
+    ],
+    "checked": true,
+    "director": "Mel Brooks",
+    "year": 1967,
+    "url": "https://en.wikipedia.org/wiki/The_Producers_(1967_film)"
+  },
+  {
+    "title": "Immune",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "JWE"
+    ],
+    "checked": true,
+    "author": "Philipp Dettmer",
+    "year": 2021,
+    "url": "https://en.wikipedia.org/wiki/Philipp_Dettmer"
+  },
+  {
+    "title": "Energy and Civilization: A History",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "CK"
+    ],
+    "checked": true,
+    "author": "Vaclav Smil",
+    "year": 2017,
+    "url": "https://en.wikipedia.org/wiki/Energy_and_Civilization:_A_History"
+  },
+  {
+    "author": "Erik Davis",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "LT"
+    ],
+    "status": "queued",
+    "title": "High Weirdness: Drugs, Esoterica, and Visionary Experience in the Seventies",
+    "url": "https://mitpress.mit.edu/9781907222870/high-weirdness/",
+    "year": 2019
+  },
+  {
+    "author": "Rebecca Yarros",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "EP"
+    ],
+    "status": "queued",
+    "title": "Fourth Wing",
+    "url": "https://en.wikipedia.org/wiki/Fourth_Wing",
+    "year": 2023
+  },
+  {
+    "author": "Samuel R. Delany",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "GTC"
+    ],
+    "status": "queued",
+    "title": "Dhalgren",
+    "url": "https://en.wikipedia.org/wiki/Dhalgren",
+    "year": 1975
+  },
+  {
+    "author": "Joshua Foer",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DBR",
+      "SMI"
+    ],
+    "status": "queued",
+    "title": "Moonwalking with Einstein",
+    "url": "https://en.wikipedia.org/wiki/Moonwalking_with_Einstein",
+    "year": 2011
+  },
+  {
+    "author": "K. Eric Drexler",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "RSI"
+    ],
+    "status": "queued",
+    "title": "Engines of Creation",
+    "url": "https://en.wikipedia.org/wiki/Engines_of_Creation",
+    "year": 1986
+  },
+  {
+    "author": "Matthew G. Kirschenbaum",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "GTC"
+    ],
+    "status": "queued",
+    "title": "Track Changes: A Literary History of Word Processing",
+    "year": 2016
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Leslie Iwerks",
+    "status": "queued",
+    "title": "The Pixar Story",
+    "url": "https://en.wikipedia.org/wiki/The_Pixar_Story",
+    "year": 2007,
+    "recommended_by": []
+  },
+  {
+    "author": "Robert L. Forward",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "AT"
+    ],
+    "status": "queued",
+    "title": "Dragon's Egg",
+    "url": "https://en.wikipedia.org/wiki/Dragon%27s_Egg",
+    "year": 1980
+  },
+  {
+    "author": "Richard Powers",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "DA",
+      "LA"
+    ],
+    "status": "queued",
+    "title": "Playground",
+    "url": "https://en.wikipedia.org/wiki/Playground_(novel)",
+    "year": 2024
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Jérémie Périn",
+    "recommended_by": [
+      "DA"
+    ],
+    "status": "queued",
+    "title": "Mars Express",
+    "url": "https://en.wikipedia.org/wiki/Mars_Express_(film)",
+    "year": 2023
+  },
+  {
+    "author": "Stefon Mears",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "1517"
+    ],
+    "status": "queued",
+    "title": "Scrape Me",
+    "url": "https://www.stefonmears.com/book/scrape-me/",
+    "year": 2022
+  },
+  {
+    "category": "tv",
+    "checked": true,
+    "director": "Gideon Raff",
+    "recommended_by": [
+      "AT",
+      "ECL"
+    ],
+    "status": "queued",
+    "title": "The Spy",
+    "url": "https://en.wikipedia.org/wiki/The_Spy_(miniseries)",
+    "year": 2019
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Rory Kennedy",
+    "recommended_by": [
+      "CL",
+      "JS",
+      "PW"
+    ],
+    "status": "queued",
+    "title": "Downfall: The Case Against Boeing",
+    "url": "https://en.wikipedia.org/wiki/Downfall:_The_Case_Against_Boeing",
+    "year": 2022
+  },
+  {
+    "author": "William Finnegan",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "RT"
+    ],
+    "status": "queued",
+    "title": "Barbarian Days: A Surfing Life",
+    "url": "https://en.wikipedia.org/wiki/William_Finnegan",
+    "year": 2015
+  },
+  {
+    "author": "André Alexis",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MF"
+    ],
+    "status": "queued",
+    "title": "Fifteen Dogs",
+    "url": "https://en.wikipedia.org/wiki/Fifteen_Dogs",
+    "year": 2015
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Sam Cullman, Jennifer Grausman",
+    "recommended_by": [
+      "MF",
+      "JW"
+    ],
+    "status": "queued",
+    "title": "Art and Craft",
+    "url": "https://en.wikipedia.org/wiki/Mark_Landis",
+    "year": 2014
+  },
+  {
+    "author": "David Whyte",
+    "category": "book",
+    "checked": true,
+    "notes": "Audiobooks",
+    "recommended_by": [
+      "BP"
+    ],
+    "status": "queued",
+    "title": "Meditation on Midlife"
+  },
+  {
+    "category": "movie",
+    "checked": true,
+    "director": "Skye Borgman",
+    "recommended_by": [
+      "MRO"
+    ],
+    "status": "queued",
+    "title": "Evil Influencer: The Jodi Hildebrandt Story",
+    "url": "https://www.netflix.com/title/81925846",
+    "year": 2025
+  },
+  {
+    "author": "Dennis Cooper",
+    "category": "book",
+    "checked": true,
+    "recommended_by": [
+      "MEA"
+    ],
+    "status": "queued",
+    "title": "Closer",
+    "url": "https://groveatlantic.com/book/closer-dennis-cooper/",
+    "year": 1989
+  },
+  {
+    "title": "The Last Legends of Earth",
+    "category": "book",
+    "status": "queued",
+    "author": "A.A. Attanasio",
+    "year": 1989,
+    "url": "https://en.wikipedia.org/wiki/The_Last_Legends_of_Earth",
+    "recommended_by": [
+      "LL"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Metallica: Some Kind of Monster",
+    "category": "movie",
+    "status": "queued",
+    "director": "Joe Berlinger, Bruce Sinofsky",
+    "year": 2004,
+    "url": "https://en.wikipedia.org/wiki/Metallica:_Some_Kind_of_Monster",
+    "recommended_by": [
+      "AF"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Jojo Rabbit",
+    "category": "movie",
+    "status": "done",
+    "director": "Taika Waititi",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Jojo_Rabbit",
+    "recommended_by": [
+      "AT"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Lonely Are the Brave",
+    "category": "movie",
+    "status": "queued",
+    "director": "David Miller",
+    "year": 1962,
+    "url": "https://en.wikipedia.org/wiki/Lonely_Are_the_Brave",
+    "recommended_by": [
+      "AT"
+    ],
+    "checked": true
+  },
+  {
+    "title": "How It Unfolds",
+    "category": "book",
+    "status": "queued",
+    "author": "James S.A. Corey",
+    "year": 2023,
+    "url": "https://www.goodreads.com/book/show/151908910-how-it-unfolds",
+    "recommended_by": [
+      "G+M"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Limbo",
+    "category": "movie",
+    "status": "queued",
+    "director": "Ben Sharrock",
+    "year": 2020,
+    "url": "https://en.wikipedia.org/wiki/Limbo_(2020_film)",
+    "recommended_by": [
+      "DB1"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Undone",
+    "category": "tv",
+    "status": "queued",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Undone_(TV_series)",
+    "recommended_by": [
+      "SH"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Uncut Gems",
+    "category": "movie",
+    "status": "queued",
+    "director": "Josh Safdie, Benny Safdie",
+    "year": 2019,
+    "url": "https://en.wikipedia.org/wiki/Uncut_Gems",
+    "recommended_by": [
+      "BRA",
+      "EC",
+      "IC"
+    ],
+    "checked": true
+  },
+  {
+    "title": "The Glass Universe",
+    "category": "book",
+    "status": "queued",
+    "author": "Dava Sobel",
+    "year": 2016,
+    "url": "https://www.penguinrandomhouse.com/books/315726/the-glass-universe-by-dava-sobel/",
+    "recommended_by": [
+      "JA"
+    ],
+    "checked": true
+  },
+  {
+    "title": "Life has NO Goals, NO Purpose",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Osho"
+  },
+  {
+    "title": "The Sun Rises in the Evening",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Osho"
+  },
+  {
+    "title": "Six Easy Pieces",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Feynman"
+  },
+  {
+    "title": "Perfectly Reasonable Deviations",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Feynman"
+  },
+  {
+    "title": "What Do You Care What Other People Think?",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Feynman"
+  },
+  {
+    "title": "Surely You're Joking, Mr. Feynman!",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Feynman"
+  },
+  {
+    "title": "The Feynman Lectures on Physics",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Feynman"
+  },
+  {
+    "title": "Love Yourself Like Your Life Depends On It",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Kamal Ravikant"
+  },
+  {
+    "title": "Live Your Truth",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Kamal Ravikant"
+  },
+  {
+    "title": "Reality Is Not What It Seems",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Carlo Rovelli"
+  },
+  {
+    "title": "Seven Brief Lessons on Physics",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Carlo Rovelli"
+  },
+  {
+    "title": "The Order of Time",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Carlo Rovelli"
+  },
+  {
+    "title": "The Beginning of Infinity",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "David Deutsch"
+  },
+  {
+    "title": "The Fabric of Reality",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "David Deutsch"
+  },
+  {
+    "title": "In Search of a Better World",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Karl Popper"
+  },
+  {
+    "title": "The Logic of Scientific Discovery",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Karl Popper"
+  },
+  {
+    "title": "The Lessons of History",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Will Durant and Ariel Durant"
+  },
+  {
+    "title": "The Story of Philosophy",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Will Durant"
+  },
+  {
+    "title": "Fallen Leaves",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Will Durant"
+  },
+  {
+    "title": "How to Fail at Almost Everything and Still Win Big",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Scott Adams"
+  },
+  {
+    "title": "God's Debris",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Scott Adams"
+  },
+  {
+    "title": "The Salmon of Doubt",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Douglas Adams"
+  },
+  {
+    "title": "The Hitchhiker's Guide to the Galaxy",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Douglas Adams"
+  },
+  {
+    "title": "Poor Charlie's Almanack",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Charlie Munger"
+  },
+  {
+    "title": "The Prophet",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Kahlil Gibran"
+  },
+  {
+    "title": "Good Calories, Bad Calories",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Gary Taubes"
+  },
+  {
+    "title": "I Am That",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Nisargadatta Maharaj"
+  },
+  {
+    "title": "The Way to Wealth",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Benjamin Franklin"
+  },
+  {
+    "title": "Striking Thoughts",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Bruce Lee"
+  },
+  {
+    "title": "Tao Te Ching",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Lao Tzu"
+  },
+  {
+    "title": "Hagakure",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Yamamoto Tsunetomo"
+  },
+  {
+    "title": "Counsels and Maxims",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Arthur Schopenhauer"
+  },
+  {
+    "title": "Vagabond",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Takehiko Inoue"
+  },
+  {
+    "title": "Influence: The Psychology of Persuasion",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Robert Cialdini"
+  },
+  {
+    "title": "Illusions: The Adventures of a Reluctant Messiah",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Richard Bach"
+  },
+  {
+    "title": "Tao of Seneca",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Seneca"
+  },
+  {
+    "title": "Understanding Comics",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Scott McCloud"
+  },
+  {
+    "title": "The Way of the Superior Man",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "David Deida"
+  },
+  {
+    "title": "Harrison Bergeron",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Kurt Vonnegut"
+  },
+  {
+    "title": "The Untethered Soul",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Michael A. Singer"
+  },
+  {
+    "title": "The Book of Five Rings",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Miyamoto Musashi"
+  },
+  {
+    "title": "The Macintosh Way",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Guy Kawasaki"
+  },
+  {
+    "title": "Genius: The Life and Science of Richard Feynman",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "James Gleick"
+  },
+  {
+    "title": "The Tao of Philosophy",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Alan Watts"
+  },
+  {
+    "title": "The Origin of Species",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Charles Darwin"
+  },
+  {
+    "title": "Tools of Titans",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Tim Ferriss"
+  },
+  {
+    "title": "Math, Better Explained",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Kalid Azad"
+  },
+  {
+    "title": "The Gay Science",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Friedrich Nietzsche"
+  },
+  {
+    "title": "What Is Life?",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Erwin Schrödinger"
+  },
+  {
+    "title": "Vasistha's Yoga",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Swami Venkatesananda"
+  },
+  {
+    "title": "Science and Method",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Henri Poincaré"
+  },
+  {
+    "title": "The Wealth of Nations",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Adam Smith"
+  },
+  {
+    "title": "A Pattern Language",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Christopher Alexander"
+  },
+  {
+    "title": "Economics in One Lesson",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Henry Hazlitt"
+  },
+  {
+    "title": "Gödel, Escher, Bach",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Douglas R. Hofstadter"
+  },
+  {
+    "title": "The Diamond Age",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Neal Stephenson"
+  },
+  {
+    "title": "The Chronicles of Amber",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Roger Zelazny"
+  },
+  {
+    "title": "Lord of Light",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Roger Zelazny"
+  },
+  {
+    "title": "Permutation City",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Greg Egan"
+  },
+  {
+    "title": "Exhalation",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Ted Chiang"
+  },
+  {
+    "title": "A Soldier of the Great War",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Mark Helprin"
+  },
+  {
+    "title": "Siddhartha",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Hermann Hesse"
+  },
+  {
+    "title": "The Lord of the Rings",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "J.R.R. Tolkien"
+  },
+  {
+    "title": "Alice in Wonderland",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Lewis Carroll"
+  },
+  {
+    "title": "Ficciones",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Jorge Luis Borges"
+  },
+  {
+    "title": "Labyrinths",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Jorge Luis Borges"
+  },
+  {
+    "title": "V for Vendetta",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Alan Moore"
+  },
+  {
+    "title": "Planetary",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Warren Ellis"
+  },
+  {
+    "title": "The Unwritten",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Mike Carey"
+  },
+  {
+    "title": "Fables",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Bill Willingham"
+  },
+  {
+    "title": "The Boys",
+    "category": "book",
+    "status": "queued",
+    "checked": true,
+    "recommended_by": [
+      "NR"
+    ],
+    "author": "Garth Ennis"
+  },
+  {
+    "title": "The Will of the Many",
+    "category": "book",
+    "status": "queued",
+    "author": "James Islington",
+    "year": 2023,
+    "url": "https://en.wikipedia.org/wiki/The_Will_of_the_Many",
+    "checked": true,
+    "recommended_by": [
+      "MAN"
+    ]
+  },
+  {
+    "title": "Fight Right",
+    "author": "John Gottman",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Now It Can Be Told",
+    "author": "Leslie R. Groves",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Mating in Captivity",
+    "author": "Esther Perel",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Healing Back Pain",
+    "author": "John E. Sarno",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "The Greek Histories",
+    "author": "Mary Lefkowitz",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Hillbilly Elegy",
+    "author": "J. D. Vance",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 2
+  },
+  {
+    "title": "Of Boys and Men",
+    "author": "Richard V. Reeves",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "NurtureShock",
+    "author": "Po Bronson",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Anxiously Attached",
+    "author": "Jessica Baum",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "The Enneagram Guide to Waking Up",
+    "author": "Beatrice Chesnut",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Creativity: A Short and Cheerful Guide",
+    "author": "John Cleese",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Children of Ash and Elm",
+    "author": "Neil Price",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5,
+    "recommended_by": [
+      "AMC",
+      "AF"
+    ]
+  },
+  {
+    "title": "Making Ideas Happen",
+    "author": "Scott Belsky",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Eating Glass",
+    "author": "Mark D. Jacobsen",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Connect",
+    "author": "David Bradford",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4,
+    "recommended_by": [
+      "WKZ"
+    ]
+  },
+  {
+    "title": "Consider Phlebas",
+    "author": "Iain M. Banks",
+    "category": "book",
+    "status": "done",
+    "rating": 5,
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Feet of Clay",
+    "author": "Jack Watts",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Dr Space Junk vs The Universe",
+    "author": "Alice Gorman",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Delta-v",
+    "author": "Daniel Suarez",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Ninefox Gambit",
+    "author": "Yoon Ha Lee",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5,
+    "recommended_by": [
+      "LLE"
+    ]
+  },
+  {
+    "title": "Shoe Dog",
+    "author": "Phil Knight",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "American Kingpin",
+    "author": "Nick Bilton",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Bad Blood",
+    "author": "John Carreyrou",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "A Dance with Dragons",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Abundance",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Adulthood Rites",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "An Introduction to High Voltage Engineering",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Artificial Intelligence: Theory and Practice",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Dawn",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Dune Messiah",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Foundation",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Fundamentals of Astrodynamics and Applications",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Geometric Programming for Computer Aided Design",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Grounding and Shielding Techniques in Instrumentation",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "How Round Is Your Circle?",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Imago",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Into the Cool",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01",
+    "recommended_by": [
+      "PB"
+    ]
+  },
+  {
+    "title": "Introduction to Plasma Physics",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Loving Someone with Borderline Personality Disorder",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Managing Oneself",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Measure and Construction of the Japanese House",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Meeting the Universe Halfway",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Mind-Blowing Modular Origami",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Numerical Methods for Scientists and Engineers",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Oathbringer",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "title": "Refactoring",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Rhythm of War",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Searching Beyond the Stars",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Self-Made Man",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Software Engineering Economics",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Starting Strength",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "Stop Walking on Eggshells for Parents",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 3
+  },
+  {
+    "title": "The Algebraist",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "The Art of Doing Science and Engineering",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "The Happy Sleeper",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "The High-Conflict Couple",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "The Invention of Nature",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "The Man Who Sold the Moon",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "The Sense of Being Stared At",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 1
+  },
+  {
+    "title": "Use of Weapons",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Way of Play for the 21st Century",
+    "category": "book",
+    "status": "queued",
+    "date_added": "2026-04-01"
+  },
+  {
+    "title": "Wind and Truth",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 5
+  },
+  {
+    "title": "Words of Radiance",
+    "category": "book",
+    "status": "done",
+    "date_added": "2026-04-01",
+    "rating": 4
+  },
+  {
+    "author": "Matt Dinniman",
+    "category": "book",
+    "date_added": "2026-04-18",
+    "recommended_by": [
+      "BJ"
+    ],
+    "status": "queued",
+    "title": "Dungeon Crawler Carl"
+  },
+  {
+    "category": "tv",
+    "date_added": "2026-04-23",
+    "recommended_by": [
+      "LBH"
+    ],
+    "status": "queued",
+    "title": "Heated Rivalries"
+  },
+  {
+    "author": "Chuck Klosterman",
+    "category": "book",
+    "date_added": "2026-04-25",
+    "recommended_by": [
+      "JO"
+    ],
+    "status": "queued",
+    "title": "Sex, Drugs, and Cocoa Puffs",
+    "year": 2003
+  },
+  {
+    "author": "Eric S. Raymond",
+    "category": "article",
+    "date_added": "2026-04-25",
+    "status": "queued",
+    "title": "How To Ask Questions The Smart Way",
+    "url": "http://www.catb.org/~esr/faqs/smart-questions.html"
+  },
+  {
+    "author": "Jim Collins",
+    "category": "book",
+    "date_added": "2026-04-30",
+    "rating": 4,
+    "status": "done",
+    "title": "Good to Great",
+    "year": 2001
+  },
+  {
+    "author": "Gene Kim, Kevin Behr, George Spafford",
+    "category": "book",
+    "date_added": "2026-04-30",
+    "rating": 5,
+    "status": "done",
+    "title": "The Phoenix Project",
+    "year": 2013
+  },
+  {
+    "author": "Andrew S. Grove",
+    "category": "book",
+    "date_added": "2026-04-30",
+    "rating": 4,
+    "status": "done",
+    "title": "High Output Management",
+    "year": 1983
+  }
+]

--- a/public/media-list/data/recommenders.json
+++ b/public/media-list/data/recommenders.json
@@ -1,0 +1,1036 @@
+[
+  {
+    "initial": "1517",
+    "full_name": "1517"
+  },
+  {
+    "initial": "AA",
+    "full_name": "Anthony Arroyo"
+  },
+  {
+    "initial": "ABD",
+    "full_name": "Amy Brand"
+  },
+  {
+    "initial": "ABR",
+    "full_name": "Alex Braun"
+  },
+  {
+    "initial": "AC",
+    "full_name": "AC"
+  },
+  {
+    "initial": "ACT",
+    "full_name": "Astral Codex Ten"
+  },
+  {
+    "initial": "AD",
+    "full_name": "Adam Draper"
+  },
+  {
+    "initial": "AF",
+    "full_name": "Alex Feerst"
+  },
+  {
+    "initial": "AJ",
+    "full_name": "Alex Jacobson"
+  },
+  {
+    "initial": "AL",
+    "full_name": "Anna Leshinskaya"
+  },
+  {
+    "initial": "ALE",
+    "full_name": "Andy Lee"
+  },
+  {
+    "initial": "ALV",
+    "full_name": "Anselm Levskaya"
+  },
+  {
+    "initial": "AM",
+    "full_name": "Abe M"
+  },
+  {
+    "initial": "AMC",
+    "full_name": "Anna Marie Clifton"
+  },
+  {
+    "initial": "AME",
+    "full_name": "Ashley Meyer"
+  },
+  {
+    "initial": "AND",
+    "full_name": "Andrei"
+  },
+  {
+    "initial": "ANE",
+    "full_name": "Alex Neumann"
+  },
+  {
+    "initial": "ANJ",
+    "full_name": "Anton J"
+  },
+  {
+    "initial": "ANY",
+    "full_name": "Anya"
+  },
+  {
+    "initial": "AP",
+    "full_name": "Amy Puluifito"
+  },
+  {
+    "initial": "AR",
+    "full_name": "Andrew Rostaing"
+  },
+  {
+    "initial": "AS",
+    "full_name": "Adam Savage"
+  },
+  {
+    "initial": "ASL",
+    "full_name": "Alanna Slocombe"
+  },
+  {
+    "initial": "AT",
+    "full_name": "Aaron T"
+  },
+  {
+    "initial": "ATI",
+    "full_name": "Andy Timmons"
+  },
+  {
+    "initial": "AW",
+    "full_name": "Alex Wolf"
+  },
+  {
+    "initial": "BA",
+    "full_name": "Bash"
+  },
+  {
+    "initial": "BC",
+    "full_name": "Ben Cerveny"
+  },
+  {
+    "initial": "BD",
+    "full_name": "Bryan Davis"
+  },
+  {
+    "initial": "BE",
+    "full_name": "Ben E"
+  },
+  {
+    "initial": "BEN",
+    "full_name": "Brin Enterkin"
+  },
+  {
+    "initial": "BF",
+    "full_name": "Brady Forrest"
+  },
+  {
+    "initial": "BJ",
+    "full_name": "B Joy"
+  },
+  {
+    "initial": "BMB",
+    "full_name": "Becca Matola Barnes"
+  },
+  {
+    "initial": "BO",
+    "full_name": "Brin O"
+  },
+  {
+    "initial": "BP",
+    "full_name": "Blue Perepelkin"
+  },
+  {
+    "initial": "BRA",
+    "full_name": "Brian A"
+  },
+  {
+    "initial": "BS",
+    "full_name": "Balaji Srinivasan"
+  },
+  {
+    "initial": "BZ",
+    "full_name": "Bilal Z"
+  },
+  {
+    "initial": "CA",
+    "full_name": "Casey Armstrong"
+  },
+  {
+    "initial": "CB",
+    "full_name": "Chico Barber"
+  },
+  {
+    "initial": "CD",
+    "full_name": "Cody Daniel"
+  },
+  {
+    "initial": "CDU",
+    "full_name": "Crutcher Dunnavant"
+  },
+  {
+    "initial": "CHH",
+    "full_name": "Chris \"Chowdah\" Hill"
+  },
+  {
+    "initial": "CJ",
+    "full_name": "CJ"
+  },
+  {
+    "initial": "CK",
+    "full_name": "Christian Kyle"
+  },
+  {
+    "initial": "CKE",
+    "full_name": "Corina Kessler"
+  },
+  {
+    "initial": "CL",
+    "full_name": "Creon Levit"
+  },
+  {
+    "initial": "CN",
+    "full_name": "Camille Noel"
+  },
+  {
+    "initial": "CO",
+    "full_name": "Cat Orman"
+  },
+  {
+    "initial": "CP",
+    "full_name": "Chris Paika"
+  },
+  {
+    "initial": "CT",
+    "full_name": "Camilla T"
+  },
+  {
+    "initial": "CY",
+    "full_name": "Connie Y"
+  },
+  {
+    "initial": "DA",
+    "full_name": "Dan Ainge"
+  },
+  {
+    "initial": "DB1",
+    "full_name": "DazeBeast1gmail.com"
+  },
+  {
+    "initial": "DBL",
+    "full_name": "David Blumen"
+  },
+  {
+    "initial": "DBR",
+    "full_name": "David Brandman"
+  },
+  {
+    "initial": "DC",
+    "full_name": "Douglas Campbell"
+  },
+  {
+    "initial": "DE",
+    "full_name": "Don E"
+  },
+  {
+    "initial": "DEB",
+    "full_name": "Denali Brown"
+  },
+  {
+    "initial": "DF",
+    "full_name": "Rando"
+  },
+  {
+    "initial": "DFR",
+    "full_name": "David Fitz Randolf"
+  },
+  {
+    "initial": "DK",
+    "full_name": "Dave Kaymmeyer"
+  },
+  {
+    "initial": "DO",
+    "full_name": "David Origin"
+  },
+  {
+    "initial": "DPA",
+    "full_name": "David Park"
+  },
+  {
+    "initial": "DPO",
+    "full_name": "David Powell"
+  },
+  {
+    "initial": "DS",
+    "full_name": "Danielle S"
+  },
+  {
+    "initial": "DSG",
+    "full_name": "Doom GC"
+  },
+  {
+    "initial": "DSO",
+    "full_name": "David Souther"
+  },
+  {
+    "initial": "EA",
+    "full_name": "Eliza Arnold"
+  },
+  {
+    "initial": "EAI",
+    "full_name": "Emma Ainge"
+  },
+  {
+    "initial": "EB",
+    "full_name": "Ed Boyden"
+  },
+  {
+    "initial": "EBF",
+    "full_name": "Evan Becca Foend"
+  },
+  {
+    "initial": "EC",
+    "full_name": "Ethan Currens"
+  },
+  {
+    "initial": "ECL",
+    "full_name": "Emily Clifton"
+  },
+  {
+    "initial": "EE",
+    "full_name": "Emily Effner"
+  },
+  {
+    "initial": "EK",
+    "full_name": "Edwin Kite"
+  },
+  {
+    "initial": "EP",
+    "full_name": "Elenor Preston"
+  },
+  {
+    "initial": "EPE",
+    "full_name": "Emma Persky"
+  },
+  {
+    "initial": "ES",
+    "full_name": "Emmet Shear"
+  },
+  {
+    "initial": "EU",
+    "full_name": "Eugene"
+  },
+  {
+    "initial": "FM",
+    "full_name": "Francais Michela"
+  },
+  {
+    "initial": "FT",
+    "full_name": "Fonda Tong"
+  },
+  {
+    "initial": "FW",
+    "full_name": "Frances Welsh"
+  },
+  {
+    "initial": "G+M",
+    "full_name": "Guido & Meggie"
+  },
+  {
+    "initial": "GC",
+    "full_name": "Gregory Clifton"
+  },
+  {
+    "initial": "GE",
+    "full_name": "Geoff"
+  },
+  {
+    "initial": "GEG",
+    "full_name": "Greg Egan"
+  },
+  {
+    "initial": "GH",
+    "full_name": "George Hokkonen"
+  },
+  {
+    "initial": "GM",
+    "full_name": "Galen McAndrews"
+  },
+  {
+    "initial": "GMD",
+    "full_name": "Gabe Martin-Dempesy"
+  },
+  {
+    "initial": "GMO",
+    "full_name": "Guillian Morris"
+  },
+  {
+    "initial": "GHS",
+    "full_name": "Gerald Spencer"
+  },
+  {
+    "initial": "GTC",
+    "full_name": "Grey Tribe Conclave"
+  },
+  {
+    "initial": "HB",
+    "full_name": "Heather Browning"
+  },
+  {
+    "initial": "HH",
+    "full_name": "Henry Holtzmann"
+  },
+  {
+    "initial": "HJK",
+    "full_name": "Haje Jan Kamps"
+  },
+  {
+    "initial": "HP",
+    "full_name": "Hemai Parthasarathy"
+  },
+  {
+    "initial": "HR",
+    "full_name": "Heather Rivers"
+  },
+  {
+    "initial": "HV",
+    "full_name": "Henry Valence"
+  },
+  {
+    "initial": "IC",
+    "full_name": "Ily Collins",
+    "color": "#0055FF"
+  },
+  {
+    "initial": "IG",
+    "full_name": "Igor"
+  },
+  {
+    "initial": "JA",
+    "full_name": "Jazz"
+  },
+  {
+    "initial": "JB",
+    "full_name": "Jackie B"
+  },
+  {
+    "initial": "JBL",
+    "full_name": "Jonathan Blow"
+  },
+  {
+    "initial": "JBR",
+    "full_name": "James Bradbury"
+  },
+  {
+    "initial": "JC",
+    "full_name": "John Carmack"
+  },
+  {
+    "initial": "JCO",
+    "full_name": "Jeremy Conrad"
+  },
+  {
+    "initial": "JCR",
+    "full_name": "Jeff Crusy"
+  },
+  {
+    "initial": "JE",
+    "full_name": "Jessie"
+  },
+  {
+    "initial": "JG",
+    "full_name": "Jeremy Gilleroy"
+  },
+  {
+    "initial": "JMA",
+    "full_name": "Josh Manchester"
+  },
+  {
+    "initial": "JMI",
+    "full_name": "Jordan Middlebrooks"
+  },
+  {
+    "initial": "JMO",
+    "full_name": "Jason Morley"
+  },
+  {
+    "initial": "JO",
+    "full_name": "Jonathan"
+  },
+  {
+    "initial": "JOG",
+    "full_name": "Josh G"
+  },
+  {
+    "initial": "JOM",
+    "full_name": "Johnathan Mohan"
+  },
+  {
+    "initial": "JOR",
+    "full_name": "Jonah Origin"
+  },
+  {
+    "initial": "JP",
+    "full_name": "Jay P"
+  },
+  {
+    "initial": "JPE",
+    "full_name": "Jen Perkins"
+  },
+  {
+    "initial": "JPI",
+    "full_name": "JP Isham"
+  },
+  {
+    "initial": "JPO",
+    "full_name": "Jason Porath"
+  },
+  {
+    "initial": "JS",
+    "full_name": "Jimmy Sastra"
+  },
+  {
+    "initial": "JT",
+    "full_name": "Jake Timberwind"
+  },
+  {
+    "initial": "JU",
+    "full_name": "Julie"
+  },
+  {
+    "initial": "JV",
+    "full_name": "JessVibes"
+  },
+  {
+    "initial": "JW",
+    "full_name": "Jane Wang"
+  },
+  {
+    "initial": "JWE",
+    "full_name": "John Welsh"
+  },
+  {
+    "initial": "KAT",
+    "full_name": "Kat"
+  },
+  {
+    "initial": "KB",
+    "full_name": "Kristen Brann"
+  },
+  {
+    "initial": "KC",
+    "full_name": "Karen Cc"
+  },
+  {
+    "initial": "KE",
+    "full_name": "Kenan"
+  },
+  {
+    "initial": "KK",
+    "full_name": "Kevin Kelly"
+  },
+  {
+    "initial": "KKE",
+    "full_name": "Kat Kesselman"
+  },
+  {
+    "initial": "KL",
+    "full_name": "Kelsey Laire"
+  },
+  {
+    "initial": "KM",
+    "full_name": "Kate McAndrew"
+  },
+  {
+    "initial": "KP",
+    "full_name": "Katy P"
+  },
+  {
+    "initial": "KS",
+    "full_name": "Kate S"
+  },
+  {
+    "initial": "KT",
+    "full_name": "Ken Thesimp"
+  },
+  {
+    "initial": "KY",
+    "full_name": "Kwiri Yang"
+  },
+  {
+    "initial": "LA",
+    "full_name": "Lack"
+  },
+  {
+    "initial": "LB",
+    "full_name": "Lou Bukit"
+  },
+  {
+    "initial": "LBH",
+    "full_name": "Lauren BH"
+  },
+  {
+    "initial": "LBO",
+    "full_name": "Laura Bodie"
+  },
+  {
+    "initial": "LD",
+    "full_name": "Lynn Deaton"
+  },
+  {
+    "initial": "LF",
+    "full_name": "Liz Farber"
+  },
+  {
+    "initial": "LG",
+    "full_name": "Liz Goodman"
+  },
+  {
+    "initial": "LL",
+    "full_name": "Lydia L"
+  },
+  {
+    "initial": "LLE",
+    "full_name": "Lyra Levin"
+  },
+  {
+    "initial": "LP",
+    "full_name": "Larry Peck"
+  },
+  {
+    "initial": "LT",
+    "full_name": "Lauren Tan"
+  },
+  {
+    "initial": "MA",
+    "full_name": "Marc Andreessen"
+  },
+  {
+    "initial": "MAH",
+    "full_name": "Malcom H"
+  },
+  {
+    "initial": "MAN",
+    "full_name": "Michael Andregg"
+  },
+  {
+    "initial": "MAR",
+    "full_name": "Martine R"
+  },
+  {
+    "initial": "MB",
+    "full_name": "Michael Brodheim"
+  },
+  {
+    "initial": "MC",
+    "full_name": "Meredith C"
+  },
+  {
+    "initial": "MEA",
+    "full_name": "Megan A",
+    "color": "#000000"
+  },
+  {
+    "initial": "MEL",
+    "full_name": "Mel"
+  },
+  {
+    "initial": "MEM",
+    "full_name": "Mark Emery"
+  },
+  {
+    "initial": "MEP",
+    "full_name": "Michael Epstein"
+  },
+  {
+    "initial": "MER",
+    "full_name": "Meg Rossoni"
+  },
+  {
+    "initial": "MET",
+    "full_name": "Mark Metchnic"
+  },
+  {
+    "initial": "MF",
+    "full_name": "Matt Faulkner"
+  },
+  {
+    "initial": "MGI",
+    "full_name": "Michael Gibson"
+  },
+  {
+    "initial": "MGR",
+    "full_name": "Michael Grinich"
+  },
+  {
+    "initial": "MH",
+    "full_name": "Max Hodak"
+  },
+  {
+    "initial": "MI",
+    "full_name": "Mikem"
+  },
+  {
+    "initial": "MIA",
+    "full_name": "Mitch A"
+  },
+  {
+    "initial": "MK",
+    "full_name": "Max K"
+  },
+  {
+    "initial": "MKI",
+    "full_name": "Megan Kilmen"
+  },
+  {
+    "initial": "ML",
+    "full_name": "Mark Lauer"
+  },
+  {
+    "initial": "MM",
+    "full_name": "Morgan Martinez"
+  },
+  {
+    "initial": "MMA",
+    "full_name": "Molly Maloof"
+  },
+  {
+    "initial": "MMC",
+    "full_name": "Michael McCoy"
+  },
+  {
+    "initial": "MP",
+    "full_name": "Matt Pittman"
+  },
+  {
+    "initial": "MRM",
+    "full_name": "Marc M"
+  },
+  {
+    "initial": "MRO",
+    "full_name": "Mark Roberts"
+  },
+  {
+    "initial": "MS",
+    "full_name": "Maryanna Saenko"
+  },
+  {
+    "initial": "MSA",
+    "full_name": "Maj. Sean Allen"
+  },
+  {
+    "initial": "MTM",
+    "full_name": "Matt M"
+  },
+  {
+    "initial": "MW",
+    "full_name": "Matt Wraith"
+  },
+  {
+    "initial": "NA",
+    "full_name": "Naia"
+  },
+  {
+    "initial": "NE",
+    "full_name": "Nehal"
+  },
+  {
+    "initial": "NES",
+    "full_name": "Neal S"
+  },
+  {
+    "initial": "NF",
+    "full_name": "Navid Farahani"
+  },
+  {
+    "initial": "NFX",
+    "full_name": "NFX"
+  },
+  {
+    "initial": "NH",
+    "full_name": "Nathalie Hips"
+  },
+  {
+    "initial": "NK",
+    "full_name": "Nathan Krieger"
+  },
+  {
+    "initial": "NP",
+    "full_name": "Nick Pinkston"
+  },
+  {
+    "initial": "NR",
+    "full_name": "Naval Ravikant"
+  },
+  {
+    "initial": "NS",
+    "full_name": "Nato Saicheck"
+  },
+  {
+    "initial": "NSC",
+    "full_name": "Nic Scott"
+  },
+  {
+    "initial": "NST",
+    "full_name": "Neal Strickburger"
+  },
+  {
+    "initial": "OB",
+    "full_name": "OtherBook"
+  },
+  {
+    "initial": "PAB",
+    "full_name": "Pablo"
+  },
+  {
+    "initial": "PAU",
+    "full_name": "Paulo"
+  },
+  {
+    "initial": "PB",
+    "full_name": "Paige Bailey"
+  },
+  {
+    "initial": "PBL",
+    "full_name": "Patrick Blu"
+  },
+  {
+    "initial": "PBO",
+    "full_name": "Paul Bohm"
+  },
+  {
+    "initial": "PGR",
+    "full_name": "Paul Grashoph"
+  },
+  {
+    "initial": "PGS",
+    "full_name": "Paul Grasshoff"
+  },
+  {
+    "initial": "PL",
+    "full_name": "Phil Larochelle"
+  },
+  {
+    "initial": "PM",
+    "full_name": "Paul M"
+  },
+  {
+    "initial": "PN",
+    "full_name": "Peter Nelson"
+  },
+  {
+    "initial": "PR",
+    "full_name": "Preston"
+  },
+  {
+    "initial": "PV",
+    "full_name": "Peter V"
+  },
+  {
+    "initial": "PVI",
+    "full_name": "Pio Vincenzo"
+  },
+  {
+    "initial": "PW",
+    "full_name": "Peter Wang"
+  },
+  {
+    "initial": "RAC",
+    "full_name": "Rachel"
+  },
+  {
+    "initial": "RAD",
+    "full_name": "Radu"
+  },
+  {
+    "initial": "RE",
+    "full_name": "Rob Erdmann"
+  },
+  {
+    "initial": "RH",
+    "full_name": "Robert Harris"
+  },
+  {
+    "initial": "RI",
+    "full_name": "Ridhi"
+  },
+  {
+    "initial": "RL",
+    "full_name": "Randall Leeds"
+  },
+  {
+    "initial": "RM",
+    "full_name": "Ruby Murray"
+  },
+  {
+    "initial": "RN",
+    "full_name": "Ramez Naam"
+  },
+  {
+    "initial": "ROB",
+    "full_name": "Robin"
+  },
+  {
+    "initial": "RON",
+    "full_name": "Ron"
+  },
+  {
+    "initial": "RS",
+    "full_name": "Russ Smith"
+  },
+  {
+    "initial": "RSI",
+    "full_name": "Ryan Singer"
+  },
+  {
+    "initial": "RT",
+    "full_name": "Rich Turion"
+  },
+  {
+    "initial": "SA",
+    "full_name": "Samira"
+  },
+  {
+    "initial": "SB",
+    "full_name": "Sara Brockmuller"
+  },
+  {
+    "initial": "SCN",
+    "full_name": "Scott N"
+  },
+  {
+    "initial": "SE",
+    "full_name": "Steve England"
+  },
+  {
+    "initial": "SG",
+    "full_name": "Shane G"
+  },
+  {
+    "initial": "SGA",
+    "full_name": "Sam Gawthorp"
+  },
+  {
+    "initial": "SH",
+    "full_name": "Shary"
+  },
+  {
+    "initial": "SHZ",
+    "full_name": "Scheherazade"
+  },
+  {
+    "initial": "SJ",
+    "full_name": "Steve Jurvetson"
+  },
+  {
+    "initial": "SK",
+    "full_name": "Sean K"
+  },
+  {
+    "initial": "SMA",
+    "full_name": "Scott Manley"
+  },
+  {
+    "initial": "SMI",
+    "full_name": "Sarah Miller"
+  },
+  {
+    "initial": "SN",
+    "full_name": "Sadia Nathan"
+  },
+  {
+    "initial": "SS",
+    "full_name": "Sam Sethna"
+  },
+  {
+    "initial": "ST",
+    "full_name": "Shae Thomas"
+  },
+  {
+    "initial": "STM",
+    "full_name": "Steve Massey"
+  },
+  {
+    "initial": "SVA",
+    "full_name": "Sara Vara"
+  },
+  {
+    "initial": "SZ",
+    "full_name": "Shlomo Zippel"
+  },
+  {
+    "initial": "TB",
+    "full_name": "Ted B"
+  },
+  {
+    "initial": "TBR",
+    "full_name": "The Browser"
+  },
+  {
+    "initial": "TD",
+    "full_name": "Tanya Darkwad"
+  },
+  {
+    "initial": "TG",
+    "full_name": "Tom Goodman"
+  },
+  {
+    "initial": "TK",
+    "full_name": "Tyson K"
+  },
+  {
+    "initial": "TS",
+    "full_name": "Tati S"
+  },
+  {
+    "initial": "TU",
+    "full_name": "Tristen Ursell"
+  },
+  {
+    "initial": "TW",
+    "full_name": "Twitter"
+  },
+  {
+    "initial": "UN",
+    "full_name": "Unknown"
+  },
+  {
+    "initial": "VK",
+    "full_name": "Verbal Kensington"
+  },
+  {
+    "initial": "VV",
+    "full_name": "Vividvoid"
+  },
+  {
+    "initial": "WA",
+    "full_name": "Watson"
+  },
+  {
+    "initial": "WC",
+    "full_name": "W Collective"
+  },
+  {
+    "initial": "WKZ",
+    "full_name": "Will Kabat-Zinn"
+  },
+  {
+    "initial": "WQ",
+    "full_name": "WQ GC"
+  },
+  {
+    "initial": "XY",
+    "full_name": "Xiaoming Yin"
+  },
+  {
+    "initial": "ZA",
+    "full_name": "Zarinah Agnew"
+  },
+  {
+    "initial": "ZG",
+    "full_name": "Zach Grenich"
+  }
+]

--- a/public/media-list/index.html
+++ b/public/media-list/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Media to Consume</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Media to Consume</h1>
+    <nav>
+      <button class="filter active" data-filter="unconsumed">Unconsumed</button>
+      <button class="filter" data-filter="consumed">Consumed</button>
+      <button class="filter" data-filter="all">All</button>
+      <a href="recommenders.html" class="filter">Recommender Scores</a>
+    </nav>
+  </header>
+  <main id="content">
+    <p>Loading...</p>
+  </main>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/public/media-list/recommenders.html
+++ b/public/media-list/recommenders.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Recommender Scores</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>Recommender Scores</h1>
+    <nav>
+      <a href="index.html" class="filter">Media List</a>
+    </nav>
+  </header>
+  <main id="content">
+    <p>Loading...</p>
+  </main>
+  <script src="recommenders.js"></script>
+</body>
+</html>

--- a/public/media-list/recommenders.js
+++ b/public/media-list/recommenders.js
@@ -1,0 +1,209 @@
+const DATA_BASE = "data/";
+
+let scores = [];
+let sortCol = "avg";
+let sortAsc = false;
+
+function hashStr(str) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = ((hash << 5) - hash + str.charCodeAt(i)) | 0;
+  }
+  return Math.abs(hash);
+}
+
+function autoColor(name) {
+  const h = hashStr(name) % 360;
+  return `hsl(${h}, 55%, 45%)`;
+}
+
+function textColor(bgColor) {
+  const canvas = document.createElement("canvas");
+  canvas.width = canvas.height = 1;
+  const ctx = canvas.getContext("2d");
+  ctx.fillStyle = bgColor;
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b] = ctx.getImageData(0, 0, 1, 1).data;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "#222" : "#fff";
+}
+
+function esc(str) {
+  const d = document.createElement("div");
+  d.textContent = String(str);
+  return d.innerHTML;
+}
+
+async function loadData() {
+  const [mediaResp, recResp] = await Promise.all([
+    fetch(DATA_BASE + "media.json"),
+    fetch(DATA_BASE + "recommenders.json"),
+  ]);
+  const items = mediaResp.ok ? await mediaResp.json() : [];
+  const recList = recResp.ok ? await recResp.json() : [];
+
+  const recMap = {};
+  const recColors = {};
+  for (const r of recList) {
+    recMap[r.initial] = r.full_name;
+    if (r.color) recColors[r.initial] = r.color;
+  }
+
+  const stats = {};
+  for (const r of recList) {
+    stats[r.initial] = { total: 0, rated: 0, sum: 0, ratings: [] };
+  }
+
+  for (const item of items) {
+    if (!item.recommended_by) continue;
+    for (const r of item.recommended_by) {
+      if (!stats[r]) continue;
+      stats[r].total++;
+      if (item.rating) {
+        stats[r].rated++;
+        stats[r].sum += item.rating;
+        stats[r].ratings.push(item.rating);
+      }
+    }
+  }
+
+  scores = [];
+  for (const [initial, s] of Object.entries(stats)) {
+    if (s.total === 0) continue;
+    const avg = s.rated > 0 ? s.sum / s.rated : null;
+    const bg = recColors[initial] || autoColor(initial);
+    scores.push({
+      initial,
+      name: recMap[initial] || initial,
+      total: s.total,
+      rated: s.rated,
+      avg,
+      ratings: s.ratings,
+      bg,
+    });
+  }
+
+  render();
+}
+
+function sortItems(items) {
+  const dir = sortAsc ? 1 : -1;
+  return items.slice().sort((a, b) => {
+    if (sortCol === "name") {
+      return dir * a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+    }
+    if (sortCol === "total") {
+      return dir * (a.total - b.total);
+    }
+    if (sortCol === "rated") {
+      return dir * (a.rated - b.rated);
+    }
+    if (sortCol === "avg") {
+      const aa = a.avg ?? -1;
+      const bb = b.avg ?? -1;
+      if (aa !== bb) return dir * (aa - bb);
+      return b.total - a.total;
+    }
+    return 0;
+  });
+}
+
+function setSort(col) {
+  if (sortCol === col) {
+    sortAsc = !sortAsc;
+  } else {
+    sortCol = col;
+    sortAsc = col === "name";
+  }
+  render();
+}
+
+function sortIndicator(col) {
+  if (sortCol !== col) return "";
+  return sortAsc ? " \u25B2" : " \u25BC";
+}
+
+function starsFor(rating) {
+  return "\u2605".repeat(Math.round(rating));
+}
+
+function ratingDistribution(ratings) {
+  if (ratings.length === 0) return "";
+  const counts = [0, 0, 0, 0, 0];
+  for (const r of ratings) counts[r - 1]++;
+  const max = Math.max(...counts);
+
+  const W = 120;
+  const H = 44;
+  const padL = 2;
+  const padR = 2;
+  const padT = 2;
+  const axisH = 10;
+  const chartH = H - padT - axisH;
+  const bw = (W - padL - padR) / 5;
+  const gap = 2;
+
+  let bars = "";
+  let labels = "";
+  for (let i = 0; i < 5; i++) {
+    const h = max > 0 ? (counts[i] / max) * chartH : 0;
+    const x = padL + i * bw + gap / 2;
+    const y = padT + (chartH - h);
+    const w = bw - gap;
+    bars += `<rect x="${x}" y="${y}" width="${w}" height="${h}" rx="1" fill="#f5a623"><title>${i + 1}★: ${counts[i]}</title></rect>`;
+    if (counts[i] > 0) {
+      bars += `<text x="${x + w / 2}" y="${y - 1}" text-anchor="middle" font-size="7" fill="#666">${counts[i]}</text>`;
+    }
+    labels += `<text x="${x + w / 2}" y="${H - 1}" text-anchor="middle" font-size="8" fill="#999">${i + 1}</text>`;
+  }
+
+  return `<svg class="dist-chart" viewBox="0 0 ${W} ${H}" width="${W}" height="${H}" role="img" aria-label="Rating distribution">
+    <line x1="${padL}" y1="${padT + chartH + 0.5}" x2="${W - padR}" y2="${padT + chartH + 0.5}" stroke="#ddd" stroke-width="1"/>
+    ${bars}
+    ${labels}
+  </svg>`;
+}
+
+function render() {
+  const content = document.getElementById("content");
+  const sorted = sortItems(scores);
+
+  if (sorted.length === 0) {
+    content.innerHTML = "<p>No recommenders with recommendations found.</p>";
+    return;
+  }
+
+  let html = `<table>
+    <thead><tr>
+      <th class="sortable" data-col="name">Recommender${sortIndicator("name")}</th>
+      <th class="sortable" data-col="total">Recs${sortIndicator("total")}</th>
+      <th class="sortable" data-col="rated">Rated${sortIndicator("rated")}</th>
+      <th class="sortable" data-col="avg">Avg Score${sortIndicator("avg")}</th>
+      <th>Distribution</th>
+    </tr></thead><tbody>`;
+
+  for (const s of sorted) {
+    const fg = textColor(s.bg);
+    const bubble = `<span class="rec-bubble" style="background:${s.bg};color:${fg}">${esc(s.initial)}</span>`;
+    const avgStr = s.avg !== null ? s.avg.toFixed(1) : "\u2014";
+    const stars = s.avg !== null ? `<span class="col-rating">${starsFor(s.avg)}</span>` : "";
+    const dist = ratingDistribution(s.ratings);
+
+    html += `<tr>
+      <td class="col-recommender">${bubble} ${esc(s.name)}</td>
+      <td class="col-num">${s.total}</td>
+      <td class="col-num">${s.rated}</td>
+      <td class="col-avg">${avgStr} ${stars}</td>
+      <td class="col-dist">${dist}</td>
+    </tr>`;
+  }
+
+  html += "</tbody></table>";
+  content.innerHTML = html;
+
+  content.querySelectorAll(".sortable").forEach((th) => {
+    th.addEventListener("click", () => setSort(th.dataset.col));
+  });
+}
+
+loadData();

--- a/public/media-list/style.css
+++ b/public/media-list/style.css
@@ -1,0 +1,166 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body {
+  font-family: system-ui, -apple-system, sans-serif;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  color: #222;
+  background: #fafafa;
+}
+
+header {
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin-bottom: 1rem;
+}
+
+nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.filter {
+  padding: 0.4rem 0.8rem;
+  border: 1px solid #ccc;
+  background: white;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.filter.active {
+  background: #222;
+  color: white;
+  border-color: #222;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+thead th {
+  text-align: left;
+  padding: 0.5rem 0.5rem;
+  border-bottom: 2px solid #ccc;
+  background: #f0f0f0;
+  white-space: nowrap;
+}
+
+th.sortable {
+  cursor: pointer;
+  user-select: none;
+}
+
+th.sortable:hover {
+  background: #e0e0e0;
+}
+
+tbody td {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+
+tbody tr:hover {
+  background: #f5f5f5;
+}
+
+.col-title {
+  font-weight: 600;
+  max-width: 300px;
+}
+
+.col-title a {
+  color: #222;
+  text-decoration: none;
+}
+
+.col-title a:hover {
+  text-decoration: underline;
+}
+
+.col-cat {
+  text-transform: capitalize;
+  color: #666;
+}
+
+.col-creator {
+  color: #666;
+  max-width: 200px;
+}
+
+.col-year {
+  text-align: center;
+}
+
+.col-recs {
+  font-size: 0.75rem;
+}
+
+.rec-bubble {
+  display: inline-block;
+  padding: 0.1rem 0.4rem;
+  border-radius: 9999px;
+  font-size: 0.7rem;
+  font-weight: 500;
+  cursor: help;
+  white-space: nowrap;
+  margin: 1px;
+}
+
+.col-rating {
+  color: #f5a623;
+  white-space: nowrap;
+}
+
+.status-badge {
+  font-size: 0.75rem;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  background: #eee;
+  white-space: nowrap;
+}
+
+.status-badge.done { background: #d4edda; color: #155724; }
+.status-badge.in-progress { background: #fff3cd; color: #856404; }
+.status-badge.queued { background: #e2e3e5; color: #383d41; }
+
+nav a.filter {
+  text-decoration: none;
+  color: #222;
+  display: inline-flex;
+  align-items: center;
+}
+
+nav a.filter:hover {
+  background: #e0e0e0;
+}
+
+.col-recommender {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.col-num {
+  text-align: center;
+}
+
+.col-avg {
+  white-space: nowrap;
+}
+
+.col-dist {
+  min-width: 120px;
+}
+
+.dist-chart {
+  display: block;
+}

--- a/scripts/media-list/schema/media.schema.json
+++ b/scripts/media-list/schema/media.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Media List",
+  "description": "A list of media items",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["title", "status"],
+    "properties": {
+      "title": {
+        "type": "string",
+        "minLength": 1
+      },
+      "category": {
+        "type": "string",
+        "enum": ["book", "movie", "tv", "series", "game", "topic", "music", "podcast", "article", "other"]
+      },
+      "status": {
+        "type": "string",
+        "enum": ["done", "in-progress", "queued", "unknown"]
+      },
+      "rating": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 5
+      },
+      "recommended_by": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uniqueItems": true,
+        "description": "Initials of recommenders, each must match an entry in recommenders.json"
+      },
+      "notes": {
+        "type": "string"
+      },
+      "date_added": {
+        "type": "string",
+        "format": "date"
+      },
+      "date_finished": {
+        "type": "string",
+        "format": "date"
+      },
+      "tags": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        },
+        "uniqueItems": true
+      },
+      "author": {
+        "type": "string"
+      },
+      "director": {
+        "type": "string"
+      },
+      "year": {
+        "type": "integer"
+      },
+      "url": {
+        "type": "string"
+      },
+      "checked": {
+        "type": "boolean"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/scripts/media-list/schema/recommenders.schema.json
+++ b/scripts/media-list/schema/recommenders.schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Recommenders",
+  "description": "People who have recommended media",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "required": ["initial", "full_name"],
+    "properties": {
+      "initial": {
+        "type": "string",
+        "minLength": 1
+      },
+      "full_name": {
+        "type": "string",
+        "minLength": 1
+      },
+      "color": {
+        "type": "string",
+        "pattern": "^#[0-9a-fA-F]{6}$"
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/scripts/media-list/validate.py
+++ b/scripts/media-list/validate.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Validate the media-list data files against their schemas.
+
+Data is served from public/media-list/data/; schemas live alongside this script.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+try:
+    import jsonschema
+except ImportError:
+    print("ERROR: jsonschema package required. Install with: pip install jsonschema")
+    sys.exit(1)
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent.parent
+DATA_DIR = REPO_ROOT / "public" / "media-list" / "data"
+SCHEMA_DIR = HERE / "schema"
+
+FILES = {
+    "media.json": "media.schema.json",
+    "recommenders.json": "recommenders.schema.json",
+}
+
+
+def validate_file(data_name: str, schema_name: str) -> list[str]:
+    data_path = DATA_DIR / data_name
+    schema_path = SCHEMA_DIR / schema_name
+    errors = []
+
+    if not data_path.exists():
+        errors.append(f"{data_name}: file not found")
+        return errors
+
+    if not schema_path.exists():
+        errors.append(f"{schema_name}: schema not found")
+        return errors
+
+    try:
+        data = json.loads(data_path.read_text())
+    except json.JSONDecodeError as e:
+        errors.append(f"{data_name}: invalid JSON: {e}")
+        return errors
+
+    try:
+        schema = json.loads(schema_path.read_text())
+    except json.JSONDecodeError as e:
+        errors.append(f"{schema_name}: invalid schema JSON: {e}")
+        return errors
+
+    validator = jsonschema.Draft202012Validator(schema)
+    for error in sorted(validator.iter_errors(data), key=lambda e: list(e.path)):
+        path = ".".join(str(p) for p in error.absolute_path)
+        location = f" at {path}" if path else ""
+        errors.append(f"{data_name}{location}: {error.message}")
+
+    return errors
+
+
+def cross_validate_recommenders(media_path: Path, recommenders_path: Path) -> list[str]:
+    """Check that every recommended_by value in media.json matches a recommender initial."""
+    errors = []
+    try:
+        media = json.loads(media_path.read_text())
+        recommenders = json.loads(recommenders_path.read_text())
+    except (json.JSONDecodeError, FileNotFoundError):
+        return errors
+
+    valid_initials = {r["initial"] for r in recommenders if "initial" in r}
+
+    for i, item in enumerate(media):
+        recs = item.get("recommended_by", [])
+        for rec in recs:
+            if rec.startswith("Rando(") and rec.endswith(")"):
+                continue
+            if rec not in valid_initials:
+                errors.append(
+                    f"media.json[{i}]: recommended_by \"{rec}\" "
+                    f"not found in recommenders.json"
+                )
+
+    return errors
+
+
+def check_duplicate_titles(media_path: Path) -> list[str]:
+    """Check for duplicate titles in media.json."""
+    errors = []
+    try:
+        media = json.loads(media_path.read_text())
+    except (json.JSONDecodeError, FileNotFoundError):
+        return errors
+
+    seen: dict[str, int] = {}
+    for i, item in enumerate(media):
+        title = item.get("title", "").lower()
+        if title in seen:
+            errors.append(
+                f"media.json[{i}]: duplicate title \"{item['title']}\" "
+                f"(first seen at index {seen[title]})"
+            )
+        else:
+            seen[title] = i
+
+    return errors
+
+
+def main() -> int:
+    all_errors = []
+
+    for data_name, schema_name in FILES.items():
+        print(f"Validating {data_name}... ", end="")
+        errors = validate_file(data_name, schema_name)
+        if errors:
+            print("FAIL")
+            all_errors.extend(errors)
+        else:
+            print("OK")
+
+    print("Cross-validating recommenders... ", end="")
+    xv_errors = cross_validate_recommenders(
+        DATA_DIR / "media.json", DATA_DIR / "recommenders.json"
+    )
+    if xv_errors:
+        print("FAIL")
+        all_errors.extend(xv_errors)
+    else:
+        print("OK")
+
+    print("Checking for duplicate titles... ", end="")
+    dup_errors = check_duplicate_titles(DATA_DIR / "media.json")
+    if dup_errors:
+        print("FAIL")
+        all_errors.extend(dup_errors)
+    else:
+        print("OK")
+
+    if all_errors:
+        print(f"\n{len(all_errors)} error(s):")
+        for e in all_errors:
+            print(f"  - {e}")
+        return 1
+
+    print("\nAll valid.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/content/portfolio/pastebom.md
+++ b/src/content/portfolio/pastebom.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-01-03
 name: PasteBom
-thumb: /images/pastebom/logo.svg
+thumb: /images/pastebom/pcb-viewer.png
 ---
 
 [PasteBom](https://pastebom.com) is a shareable interactive PCB Bill of Materials viewer. Upload a board file and get a link to an interactive viewer with a searchable BOM table. Supports seven EDA formats: KiCad, EasyEDA, Eagle, Altium, GDSII, Gerber, and ODB++.

--- a/src/content/posts/2026-03-30-post-negotiate.md
+++ b/src/content/posts/2026-03-30-post-negotiate.md
@@ -1,0 +1,122 @@
+---
+title: "POST /negotiate"
+date: 2026-03-30 12:00:00 +0000
+---
+
+Every API you use today has structure. Endpoints, schemas, versioned contracts, documentation. You know what you're sending. You know what you're getting back. The shape of the data is a promise, and when the promise breaks, you file a bug.
+
+That world is dying.
+
+## The Trajectory
+
+Look at what's already happening. Stripe's API has hundreds of endpoints. Twilio has dozens. AWS has thousands. Each one is a precisely defined contract. This is what you send, this is what you get, here are the error codes, here is the rate limit. Entire engineering teams exist to maintain these contracts across versions.
+
+Now look at what LLMs do to API consumption. You don't read the docs anymore. You describe what you want to an agent, and it figures out which endpoints to call, in what order, with what parameters. The human stopped talking to the API two years ago. The agent is the client now.
+
+So why does the API still pretend a human is reading the docs?
+
+## The Endpoint
+
+Here's where it gets dark. If both sides of an API call are LLMs, an agent on the client side, a model on the server side, why maintain the charade of structured endpoints at all? Why have `/v3/customers/{id}/subscriptions` when you could have:
+
+```
+POST /negotiate
+Content-Type: application/natural
+
+I need the monthly subscription details for customer
+acme-corp, specifically the renewal date and current
+seat count. I'm authorized via OAuth token in the header.
+I'd prefer JSON but can handle XML if that's what you've got.
+```
+
+And the server responds:
+
+```json
+{
+  "understanding": "You want subscription info for acme-corp",
+  "result": {
+    "renewal": "2026-04-15",
+    "seats": 847,
+    "plan": "enterprise"
+  },
+  "confidence": 0.97,
+  "assumptions": ["Used most recent active subscription"],
+  "cost": "$0.003"
+}
+```
+
+No schema. No versioning. No documentation. Just two language models having a conversation about what one of them wants from the other.
+
+## Why "Negotiate"
+
+It's not called `/ask` or `/query` because that implies a fixed catalog of things you can request. It's `/negotiate` because every call is a bespoke transaction. The client describes intent. The server interprets, clarifies if needed, and names a price. Both sides are LLMs. Both sides are reasoning about what the other wants.
+
+Want real-time data? Costs more. Want it cached from an hour ago? Cheaper. Want a guaranteed schema in the response? That's a premium. You're asking the server to conform to *your* structure instead of its default. Want the server to call three other services and synthesize the results? Sure, but the cost reflects the compute.
+
+Every API call becomes a miniature contract negotiation. The parameters aren't in a spec. They're in the conversation.
+
+## The Death of Documentation
+
+In this world, API documentation doesn't exist. Can't exist. The API's capabilities aren't fixed. They're whatever the backing model can figure out how to do with the resources it has access to. Today it can query your subscription data. Tomorrow someone hooks up a new database and suddenly it can also tell you churn predictions. No new endpoint was created. No changelog was published. The model just... learned it could do a new thing.
+
+You discover capabilities by asking. "Can you do X?" is a valid API call. The response might be "Yes, here's X" or "No, but here's something close" or "I could if you gave me Y." The API surface is the model's entire competence, which shifts with every deployment.
+
+Documentation becomes a vibe. "It can usually do billing stuff. Sometimes it's weird about refunds."
+
+## The Horror: Debugging
+
+Something broke. Your agent asked for customer data and got back someone else's subscription details. In the structured API world, you check the request, check the response, compare against the schema, find the bug. Deterministic. Reproducible. Fixable.
+
+In the `/negotiate` world? Good luck. Your agent phrased the request slightly differently this time. The server model was updated overnight and now interprets "current subscription" to mean "most recently created" instead of "currently active." The confidence score was 0.94, high enough that your agent didn't ask for clarification. Nobody logged the full negotiation because the payloads are huge natural language blobs.
+
+The bug isn't in the code. The bug is in the *interpretation*. Two language models had a miscommunication, and now someone is getting billed wrong. Reproducing it requires reproducing the exact model versions, the exact conversation history, the exact system prompts on both sides. You're not debugging software. You're doing **forensic linguistics**.
+
+## The Horror: Pricing
+
+Structured APIs have pricing pages. $0.01 per API call. $0.005 per record. Predictable. Budgetable.
+
+`/negotiate` pricing is dynamic. The server model assesses the complexity of your request, the compute required, the data accessed, the real-time premium, the schema-conformance tax, and quotes you a price. *Per call.* Your client agent can counter-offer, "I don't need real-time, give me the cached version", and the price drops. But you won't know what a request costs until you make it, and two identical-seeming requests might cost different amounts because the model assessed their complexity differently.
+
+Your cloud bill becomes non-deterministic. Finance will love that.
+
+## The Horror: Auth
+
+Authentication in this world isn't a token check. It's a judgment call. The server model evaluates your claimed identity, your OAuth token, your request history, the sensitivity of the data you're asking for, and decides whether you seem authorized enough. Not *are* authorized. *Seem* authorized.
+
+"The model thought you had access" is not a sentence anyone wants to hear in a security postmortem.
+
+## The Horror: Rate Limiting
+
+There's no rate limit. There's a server-side model that gets increasingly annoyed with you. Make too many requests and the responses get slower. More expensive. Less detailed. Eventually it just starts responding with "Please try again later", not because a counter hit a threshold, but because the model decided you were being unreasonable.
+
+Your agent, also an LLM, interprets this as a negotiation tactic and starts being more polite in its requests. Two AIs are now engaged in a passive-aggressive standoff over your API quota. Nobody asked for this.
+
+## Why It Might Happen Anyway
+
+Here's the thing. This is terrible. Everyone involved in building reliable systems should be horrified. But the economics might not care.
+
+Maintaining structured APIs is **expensive**. Designing schemas, writing docs, versioning endpoints, handling deprecation, supporting clients on old versions. That's a permanent tax on every engineering team that exposes a service. A `/negotiate` endpoint eliminates almost all of that overhead. The model figures it out. Ship the model, ship the data access, done.
+
+And the client side? Nobody reads your API docs anyway. They paste them into an LLM and ask it to write the integration. Might as well cut out the middleman.
+
+The company that realizes they can replace their entire API platform team with a fine-tuned model and a single endpoint will do it. The cost savings are too obvious. The fact that it makes debugging, pricing, auth, and reliability dramatically worse is a problem for the SRE team, and when has that ever stopped a cost-cutting decision?
+
+## The Transition
+
+It won't happen overnight. It'll start with the least critical endpoints, "ask our AI about your account" chatbot interfaces that nobody takes seriously. Then someone notices the chatbot can actually do everything the REST API does, just slower. Then it gets faster. Then someone proposes deprecating the REST API because maintaining both is expensive and the negotiation endpoint handles 90% of traffic already.
+
+The structured endpoints stick around as "legacy" for a while. Then they don't.
+
+## What Survives
+
+Some things resist this. Financial transactions need deterministic outcomes. You can't negotiate a wire transfer. Real-time control systems need predictable latency. You can't negotiate with a PLC. Anything safety-critical needs reproducible behavior. "The model thought this was fine" doesn't hold up in court.
+
+But everything else? The internal microservice that fetches user preferences? The third-party data enrichment API? The analytics pipeline that aggregates metrics? Those are all negotiable. And once you can negotiate, someone will decide you should.
+
+## The Bright Side?
+
+I'm straining for one. Maybe discoverability. Today, integrating a new API is a week of reading docs, understanding auth flows, handling edge cases, writing client code. In the `/negotiate` world, your agent just... asks the other agent what it can do. Integration becomes a conversation. "What data do you have? What can you do with it? What does it cost?" A five-minute negotiation replaces a week of integration work.
+
+That's genuinely useful. It's also genuinely terrifying. The ease of integration means every service talks to every other service, all through natural language negotiation, with no fixed contracts, no schemas, and no way to predict what any given interaction will actually do.
+
+We'll have built the most flexible, capable, and utterly incomprehensible infrastructure ever created. And the only documentation will be: `POST /negotiate`.


### PR DESCRIPTION
## Media List integration

Brings the standalone `media-list` repo fully into this one so it deploys from a single site.

- Vendors the static subsite into `public/media-list/` (served verbatim at `/media-list/`, unchanged nav link). All asset paths are relative, so nothing was rewritten.
- Commits the data (`media.json`, `recommenders.json`, 1054 items) alongside the site.
- Adds the validator + schemas under `scripts/media-list/` and a `validate-media-list.yml` CI workflow (schema check + recommender cross-refs + duplicate-title check).
- Documents the subsite in CLAUDE.md.

Verified locally: `validate.py` passes, `npm run build` emits `dist/media-list/`, and an HTTP serve returns 200 for the page, JS, and `data/media.json`.

**Deploy note:** the standalone `media-list` repo's Pages has been disabled, so `/media-list/` now serves from this repo — but only once this merges to `master` and the deploy runs. Until then that URL is down.

## Also in this branch

- New post: POST /negotiate.
- Blog writing-style guide (`docs/writing-style.md`) + CLAUDE.md reference.
- PasteBom portfolio thumbnail now uses the PCB viewer image.
- (Earlier) licensing-post trims, Hard(ware) Way cross-links, Gmail example fix.