### PR TITLE
Use relative path for Media List nav link

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -11,7 +11,7 @@ const navItems = [
   { text: 'Blog', url: '/blog/' },
   { text: 'Resume', url: '/resume/MatthewGoodman.pdf' },
   { text: 'Press', url: '/press/' },
-  { text: 'Media List', url: 'https://meawoppl.github.io/media-list/' },
+  { text: 'Media List', url: '/media-list/' },
   { text: 'Art Ideas', url: '/art-ideas/' },
 ];
 ---


### PR DESCRIPTION
Both subsites now serve from this repo, so the Media List nav link uses the relative `/media-list/` path instead of the absolute `https://meawoppl.github.io/media-list/` URL. Cosmetic; behavior is identical.