### PR TITLE
Add write-up for Modular DRSSTC Driver

### DIFF
--- a/public/art-ideas/docs/index.json
+++ b/public/art-ideas/docs/index.json
@@ -6,6 +6,7 @@
   "flesh-ninja-danger-bot": "Flesh Ninja (Danger bot)",
   "illuminated-manuscripts": "Illuminated Manuscripts",
   "mattchat": "MattChat",
+  "modular-drsstc-driver": "Modular DRSSTC Driver",
   "noncon-trap": "NonCon Trap",
   "puzzles-by-evil-corp": "Puzzles by Evil Corp",
   "signal-book-club": "Signal Book Club",

--- a/public/art-ideas/docs/modular-drsstc-driver.json
+++ b/public/art-ideas/docs/modular-drsstc-driver.json
@@ -1,0 +1,15 @@
+{
+  "slug": "modular-drsstc-driver",
+  "title": "Modular DRSSTC Driver",
+  "blocks": [
+    {
+      "type": "p",
+      "text": "The core is a half-bridge on a small board that connectorizes directly onto a big shared set of bus rails. Stack as many boards as you want along the rails to add current capacity — enough for high-current bursts or QCW (quasi-continuous-wave) operation."
+    },
+    {
+      "type": "p",
+      "text": "The switches are TO-247 packages. Beyond being cheap and everywhere, TO-247 has good tpd/area — a lot of thermal power dissipation for the footprint it occupies — which is exactly what you want when you're packing modules tightly along a rail and trying to get rid of heat."
+    }
+  ],
+  "images": []
+}


### PR DESCRIPTION
Adds a hand-authored detail modal for the Modular DRSSTC Driver: half-bridge boards stacking on shared bus rails for high-current / QCW operation, and TO-247 chosen for its good tpd/area (thermal dissipation per footprint).