### PR TITLE
Add Allergy Bug and Instant Gallery art ideas

### DIFF
--- a/public/art-ideas/data/ideas.json
+++ b/public/art-ideas/data/ideas.json
@@ -21,6 +21,15 @@
     ]
   },
   {
+    "title": "Allergy Bug",
+    "summary": "A wearable air-quality monitor for bugging your own allergies. It logs local air quality, tags each reading with GPS from your phone, and cross-references that against weather and larger global allergen/pollen sources to work out what is actually setting you off.",
+    "themes": [
+      "Bio/Body",
+      "Electronics",
+      "Self-Improvement"
+    ]
+  },
+  {
     "title": "Aroura Desartalis",
     "summary": "Aroura Borealis, but \"portable\"",
     "status": "Notion Only",
@@ -136,6 +145,15 @@
     "themes": [
       "Electronics",
       "Old/Modern"
+    ]
+  },
+  {
+    "title": "Instant Gallery",
+    "summary": "Point your phone at anything — a puddle, a trash can, your half-eaten lunch — and an agent writes it up in full international art-speak, complete with an invented artist attribution, medium, and year, then prints a fancy museum-style placard. The whole joke is that anything becomes 'art' the moment it gets the tag.",
+    "themes": [
+      "Prank",
+      "Digital Culture",
+      "Expectation Violation"
     ]
   },
   {


### PR DESCRIPTION
Two new ideas:
- **Allergy Bug** — wearable air-quality monitor that GPS-tags allergy readings and cross-references weather + global allergen data. Tags: Bio/Body, Electronics, Self-Improvement.
- **Instant Gallery** — photograph anything, an agent writes international art-speak + invented attribution and prints a museum placard; the gag is that the tag makes it 'art'. Tags: Prank, Digital Culture, Expectation Violation.