### PR TITLE
Add Blindsight and Too Like the Lightning recommenders

### DIFF
--- a/public/media-list/data/media.json
+++ b/public/media-list/data/media.json
@@ -9995,11 +9995,25 @@
     "checked": true
   },
   {
+    "title": "Blindsight",
+    "category": "book",
+    "status": "queued",
+    "recommended_by": [
+      "AB"
+    ],
+    "author": "Peter Watts",
+    "year": 2006,
+    "url": "https://en.wikipedia.org/wiki/Blindsight_(Watts_novel)",
+    "checked": true
+  },
+  {
     "title": "Too Like the Lightning",
     "category": "book",
     "status": "queued",
     "recommended_by": [
-      "MEA"
+      "MEA",
+      "MSC",
+      "AB"
     ],
     "author": "Ada Palmer",
     "year": 2016,

--- a/public/media-list/data/recommenders.json
+++ b/public/media-list/data/recommenders.json
@@ -8,6 +8,10 @@
     "full_name": "Anthony Arroyo"
   },
   {
+    "initial": "AB",
+    "full_name": "Andrew Blinn"
+  },
+  {
     "initial": "ABD",
     "full_name": "Amy Brand"
   },
@@ -720,6 +724,10 @@
   {
     "initial": "MSA",
     "full_name": "Maj. Sean Allen"
+  },
+  {
+    "initial": "MSC",
+    "full_name": "EmmaCOfficeHours"
   },
   {
     "initial": "MTM",


### PR DESCRIPTION
Media-list additions from **Office Hours at Zeitgeist**:

- Add **"Blindsight"** (Peter Watts, 2006) — recommended by Andrew Blinn
- Add new recommenders: **Andrew Blinn** (AB) and **EmmaCOfficeHours** (MSC)
- Credit both new recommenders on **"Too Like the Lightning"** (Ada Palmer)

`python3 scripts/media-list/validate.py` passes.