### PR TITLE
Blog image sizing fix and reading taste profile

### DIFF
--- a/docs/reading-taste-profile.md
+++ b/docs/reading-taste-profile.md
@@ -1,0 +1,124 @@
+# Reading Taste Profile
+
+A working model of what Matt likes and doesn't like in books, distilled from the
+`/media-list` ratings (189 rated books: 54 at 5★, 66 at 4★, 9 at 1–2★) plus a short
+taste interview. Intended as a reference for recommendations — human or LLM. If you're
+suggesting a book, run it past the "How to pitch me a book" checklist at the bottom.
+
+## One-line version
+
+An omnivore who reads for four different reasons — **big ideas, how things work,
+people/self, and story/prose** — and toggles between them by mood. The 5★ books are
+the ones that pair **rigor with wonder**: a real idea or real mechanism, taken
+seriously, that also opens the world up. The books that die are the ones with neither
+— platitudes stretched to book length, or hand-waving dressed as rigor.
+
+## What I reliably love
+
+**1. Iain M. Banks and the high-concept Culture space opera.** The single strongest
+signal in the whole list — *Player of Games, Use of Weapons, Excession, Look to
+Windward, Matter, Consider Phlebas, The Algebraist* all at 5★. Post-scarcity,
+big-canvas, morally serious space opera with wit is a bullseye.
+
+**2. Big-idea / "what if" hard SF.** Ted Chiang (*Stories of Your Life*), Vernor Vinge
+(*A Fire Upon the Deep*), Liu Cixin (*Three-Body Problem*), Le Guin (*The
+Dispossessed*), PKD (*Do Androids Dream*), *This Is How You Lose the Time War*,
+*Ninefox Gambit*. Concept-driven SF where the idea is the engine.
+
+**3. Immersive, rigorously-built epic fantasy.** Sanderson's Stormlight Archive —
+*Way of Kings, Words of Radiance, Oathbringer, Rhythm of War, Wind and Truth* — all
+top-rated. Systematized magic and 1000-page worlds are a feature, not a cost. (Note:
+you gave *The Name of the Wind* only 3★ — lyrical-but-loose fantasy lands softer than
+engineered-world fantasy.)
+
+**4. Octavia Butler / social-SF that thinks hard about people.** The whole Xenogenesis
+/ Lilith's Brood trilogy (*Dawn, Adulthood Rites, Imago*) at 5★. Gender, biology,
+otherness taken seriously.
+
+**5. Operational-excellence nonfiction with real mechanism.** *Toyota Kata,
+Creativity Inc., High Output Management, Good to Great, The Phoenix Project, The
+Toyota Way, The First 90 Days.* Specific, systems-level, mechanism-rich management —
+how good organizations actually work. (Contrast the dealbreakers below.)
+
+**6. Deep technical & craft texts.** Plasma physics (Chen, Hazeltine), rockets
+(*Ignition!*, astrodynamics), math done beautifully (Conway's *Symmetries of Things*,
+Pólya's *How to Solve It*, quasicrystals & geometry), *Hacker's Delight*, *The Art of
+Doing Science and Engineering*, *Bicycling Science*. You read real textbooks for
+pleasure. Density is welcome when it's earned.
+
+**7. Sweeping true stories — endurance, deep history, anthropology.** *Endurance:
+Shackleton's Voyage, Children of Ash and Elm, Under the Banner of Heaven, Exploding
+the Phone, Turing's Cathedral, The High Frontier.* Meticulously-researched narrative
+nonfiction about people doing hard things, or about how a whole world worked.
+
+**8. Sense-of-wonder science.** *Mycelium Running, Reinventing the Sacred, Cosmic
+Evolution.* Books that make a corner of reality feel vast and alive.
+
+**9. Substantive people / self-understanding.** When it has real depth: *Adult
+Children of Emotionally Immature Parents* (5★), *The High-Conflict Couple* (5★),
+Esther Perel's *Mating in Captivity*, attachment books (*Anxiously Attached*), *Iron
+John*, *The Enneagram Guide to Waking Up*. Psychology that's specific and useful, not
+inspirational.
+
+## The 5★ "it" factor — what pushes a 4 to a 5
+
+- A **genuine idea or genuine mechanism** at the core, taken all the way.
+- **Rigor plus wonder** together — precise *and* expansive. Either alone is a 4.
+- Rewards a **systems-thinking** reader; assumes you can handle complexity.
+- **Length is not a cost.** Doorstoppers and dense textbooks over-index in the 5★ set.
+- Often **morally serious** without being preachy (Banks, Butler, Le Guin, Russell's
+  *History of Western Philosophy*).
+
+## What I don't like (dealbreakers)
+
+**1. Platitudes stretched to book length.** The clearest negative cluster: *The One
+Minute Manager* (2★), *The Amazon Way* (2★). One thin idea, padded, told as a parable.
+This is the flip side of loving *Toyota Kata* — you like management books with real
+operational mechanism and specificity, and bounce off the airport-bookstore fluff.
+**Discriminator: is there a real, specific mechanism, or is it a slogan?**
+
+**2. Pseudoscience and overreach dressed as rigor.** *The Sense of Being Stared At*
+(Sheldrake, 1★), *Shadows of the Mind* (Penrose's quantum-consciousness argument, 1★).
+Hand-wavy claims wearing a lab coat are worse than honest speculation.
+
+**3. Recipe-books without ideas.** The sharpest tell in the data: *Mycelium Running*
+(5★) vs Stamets's *The Mushroom Cultivator* (2★) and *Growing Gourmet and Medicinal
+Mushrooms* (2★) — same author, same topic. You love the **visionary, idea-rich** book
+and bounce off the **how-to cultivation manuals**. Important nuance: this is NOT
+"how-to is bad" — you rate real textbooks 4–5★. It's that a step-by-step recipe guide
+with no ideas underneath is dead on the page, even when a dense technical text on the
+same shelf is a delight. The presence of *ideas/mechanism*, not the presence of
+*practicality*, is what matters.
+
+**4. (Lower confidence) Memoir-as-argument / literary that doesn't connect.**
+*Hillbilly Elegy* (2★), Roth's *Deception* (2★). Not a strong pattern, but literary
+fiction and political memoir are the shakiest categories for you.
+
+## Nuances & tensions worth remembering
+
+- **Mood-driven, not lane-locked.** You toggle between concept-dense hard SF and
+  immersive epics depending on where your head is; don't assume one mode.
+- **Leadership reading is bimodal** — dense/operational = love, thin/inspirational =
+  reject. Screen hard on this before recommending anything in the genre.
+- **"Practical" is not the axis; "ideas" is.** Textbooks yes, recipe manuals no.
+- **You read for all four reasons** (ideas / how-things-work / people / prose), so a
+  book that hits two or three at once (Banks, Butler, *The Overstory*, *Anathem*) is a
+  near-guaranteed win.
+- Nonfiction motives, in your words: getting better at work, understanding people and
+  yourself, fueling an active project/hobby, and plain curiosity — all four.
+
+## How to pitch me a book (recommender checklist)
+
+Score a candidate on these; the winners hit most:
+
+1. Is there a **real idea or real mechanism** at its center? (If it's a slogan, stop.)
+2. Does it pair **precision with wonder**, not just one?
+3. Would a **systems thinker** feel respected, not condescended to?
+4. If it's management/self-help: is it **specific and operational**, or airport fluff?
+5. If it's technical: does it have **ideas under the procedure**, or is it a recipe?
+6. Is any big claim **honestly earned**, or is it woo in a lab coat? (Instant kill.)
+7. Bonus: does it hit **two+ of {ideas, how-things-work, people, prose}** at once?
+
+Safe bets if I haven't read them: more Banks-adjacent literary space opera, more
+big-idea hard SF, rigorously-built epic fantasy, meticulous narrative nonfiction about
+people doing hard things, and deep-but-alive technical/science writing.

--- a/src/styles/main.scss
+++ b/src/styles/main.scss
@@ -193,7 +193,6 @@ main.cell {
 // Blog post image styling
 .post img, .post-content img {
   max-width: 100%;
-  width: 100%;
   height: auto;
   display: block;
   margin: 1.5rem auto;
@@ -221,7 +220,6 @@ main.cell {
   .post img, .post-content img {
     margin: 1rem auto;
     border-radius: 4px;
-    width: 100%;
   }
 }
 


### PR DESCRIPTION
Two small, unrelated bits from this session:

- **CSS:** stop forcing `.post img` to `width: 100%`. Blog images now render at natural size up to the column width instead of being upscaled — fixes blurry, oversized portrait thumbnails on mobile and desktop. `max-width: 100%` still prevents overflow. Verified with `astro build`.
- **Docs:** add `docs/reading-taste-profile.md` — a taste model distilled from the media-list ratings (what I like / don't like, plus a recommender checklist).